### PR TITLE
To match schemes with urls more agressively.

### DIFF
--- a/src/utils/findProvider.js
+++ b/src/utils/findProvider.js
@@ -48,8 +48,8 @@ const findProvider = (url) => {
       return url.includes(domain);
     }
     return schemes.some((scheme) => {
-      let reg = new RegExp(scheme.replace(/\*/g, '(.*)'), 'i');
-      return url.match(reg);
+      let reg = new RegExp(scheme.replace('www.', '').replace(/\*/g, '(.*)'), 'i');
+      return url.replace('www.', '').match(reg);
     });
   });
 


### PR DESCRIPTION
A certain site, such as Instagram, is normally using its perma urls starting with www., but the current schemes in providers.json doesn't include it, and eventually ended up with 'no provider error'.