### PR TITLE
Fixed fetch for providers.json URLs containing `{format}`

### DIFF
--- a/src/utils/fetchEmbed.js
+++ b/src/utils/fetchEmbed.js
@@ -10,6 +10,9 @@ const fetchEmbed = (url, provider) => {
       url: resourceUrl,
     } = provider;
 
+
+    resourceUrl = resourceUrl.replace(/\{format\}/g, 'json');
+
     let link = `${resourceUrl}?format=json&url=${encodeURIComponent(url)}`;
 
     return fetch(link).then((res) => {


### PR DESCRIPTION
no issue
- some `url` attributes in `providers.json` contain a `{format}` string that needs replacing to avoid 404s
- perform a basic regex replacement inside `fetchEmbed` so the correct endpoint is requested
- `fetchEmbed` was chosen because it's the place where the `json` format is currently hardcoded