### PR TITLE
Moved bellajs into devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "reset": "node reset"
   },
   "dependencies": {
-    "bellajs": "^7.2.2",
     "node-fetch": "^2.1.2",
     "promise-wtf": "^1.2.4"
   },
   "devDependencies": {
+    "bellajs": "^7.2.2",
     "debug": "^3.1.0",
     "eslint": "^4.19.1",
     "eslint-config-goes": "^1.0.0",


### PR DESCRIPTION
The `bellajs` package is only used in the tests so i've moved it into dev deps :+1:

```
> grep -R bellajs ./
./test/specs/main.js:} = require('bellajs');
./package.json:    "bellajs": "^7.2.2",
```