### PR TITLE
Settable provider list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Return a Promise object.
 
 Return boolean. True if the URL matches with any provider in the list.
 
+#### .setProviderList(Array of provider definitions)
+
+Sets the list of providers to use, overriding the defaults.
+
+This can be useful for whitelisting only certain providers, or for adding
+custom providers.
+
+For the expected format, see the
+[default list](https://raw.githubusercontent.com/ndaidong/oembed-parser/master/src/utils/providers.json).
+
 
 #### Provider list
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,14 +4,17 @@ const {
   isValidURL,
   findProvider,
   fetchEmbed,
+  providersFromList,
 } = require('./utils');
 
+const defaultProviderList = require('./utils/providers.json');
+let providers = providersFromList(defaultProviderList);
 
 const extract = async (url, params) => {
   if (!isValidURL(url)) {
     throw new Error('Invalid input URL');
   }
-  const p = findProvider(url);
+  const p = findProvider(url, providers);
   if (!p) {
     throw new Error(`No provider found with given url "${url}"`);
   }
@@ -20,10 +23,15 @@ const extract = async (url, params) => {
 };
 
 const hasProvider = (url) => {
-  return findProvider(url) !== null;
+  return findProvider(url, providers) !== null;
+};
+
+const setProviderList = (list) => {
+  providers = providersFromList(list);
 };
 
 module.exports = {
   extract,
   hasProvider,
+  setProviderList,
 };

--- a/src/utils/findProvider.js
+++ b/src/utils/findProvider.js
@@ -1,44 +1,6 @@
 // utils -> findProvider
 
-
-const providerList = require('./providers.json');
-
-const getHostname = (url) => {
-  const match = url.match(/:\/\/(www[0-9]?\.)?(.[^/:]+)/i);
-  if (match && match.length > 2 && typeof match[2] === 'string' && match[2].length > 0) {
-    return match[2];
-  }
-  return null;
-};
-
-const providers = providerList.map((item) => {
-  const {
-    provider_name, // eslint-disable-line camelcase
-    provider_url, // eslint-disable-line camelcase
-    endpoints,
-  } = item;
-
-  const endpoint = endpoints[0];
-  const {
-    schemes = [],
-    url,
-  } = endpoint;
-
-  const hostname = getHostname(url);
-  const domain = hostname ? hostname.replace('www.', '') : '';
-
-  return {
-    provider_name, // eslint-disable-line camelcase
-    provider_url, // eslint-disable-line camelcase
-    schemes,
-    domain,
-    url,
-  };
-}).filter((item) => {
-  return item.domain !== '';
-});
-
-const findProvider = (url) => {
+const findProvider = (url, providers) => {
   const candidates = providers.filter((provider) => {
     const {
       schemes,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,4 +3,5 @@ module.exports = {
   findProvider: require('./findProvider'),
   fetchEmbed: require('./fetchEmbed'),
   logger: require('./logger'),
+  providersFromList: require('./providersFromList'),
 };

--- a/src/utils/providersFromList.js
+++ b/src/utils/providersFromList.js
@@ -1,0 +1,40 @@
+// utils -> providersFromList
+
+const getHostname = (url) => {
+  const match = url.match(/:\/\/(www[0-9]?\.)?(.[^/:]+)/i);
+  if (match && match.length > 2 && typeof match[2] === 'string' && match[2].length > 0) {
+    return match[2];
+  }
+  return null;
+};
+
+const providersFromList = (list) => {
+  return list.map((item) => {
+    const {
+      provider_name, // eslint-disable-line camelcase
+      provider_url, // eslint-disable-line camelcase
+      endpoints,
+    } = item;
+
+    const endpoint = endpoints[0];
+    const {
+      schemes = [],
+      url,
+    } = endpoint;
+
+    const hostname = getHostname(url);
+    const domain = hostname ? hostname.replace('www.', '') : '';
+
+    return {
+      provider_name, // eslint-disable-line camelcase
+      provider_url, // eslint-disable-line camelcase
+      schemes,
+      domain,
+      url,
+    };
+  }).filter((item) => {
+    return item.domain !== '';
+  });
+};
+
+module.exports = providersFromList;

--- a/test/specs/main.js
+++ b/test/specs/main.js
@@ -17,6 +17,7 @@ const AP = require('../../index');
 const {
   extract,
   hasProvider,
+  setProviderList,
 } = AP;
 
 const UTILS = require('../../src/utils/index');
@@ -237,5 +238,28 @@ test(`Testing .hasProvider() method`, (t) => {
   t.ok(isFunction(hasProvider), 'hasProvider must be a function');
   t.equals(hasProvider('https://www.youtube.com/watch?v=zh9NgGf3cxU'), true, 'YouTube URL has oEmbed provider');
   t.equals(hasProvider('https://trello.com/b/BO3bg7yn/notes'), false, 'Trello URL has no oEmbed provider');
+  t.end();
+});
+
+test(`Testing .setProviderList() method`, (t) => {
+  const customProviderOnly = [
+    {
+      provider_name: 'Example', // eslint-disable-line camelcase
+      provider_url: 'http://www.example.org', // eslint-disable-line camelcase
+      endpoints: [
+        {
+          schemes: [
+            'http://www.example.org/media/*',
+          ],
+          url: 'http://www.example.org/oembed',
+        },
+      ],
+    },
+  ];
+
+  t.ok(isFunction(setProviderList), 'setProviderList must be a function');
+  setProviderList(customProviderOnly);
+  t.equals(hasProvider('https://www.youtube.com/watch?v=zh9NgGf3cxU'), false, 'YouTube URL has no oEmbed provider');
+  t.equals(hasProvider('http://www.example.org/media/abcdef'), true, 'www.example.org URL has oEmbed provider');
   t.end();
 });


### PR DESCRIPTION
This adds a new API function `setProviderList` permitting users of the package to supply their own provider list which may be useful in scenarios requiring:
1. whitelisting only certain providers
2. adding custom providers not on the oembed.com list