### PR TITLE
remove type field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "author": "@ndaidong",
   "main": "./index.js",
-  "type": "module",
   "engines": {
     "node": ">= 8.6"
   },


### PR DESCRIPTION
Because `type` is required on `package.json`, when this module is loaded under Node.js 13.x it throws an error

```
(node:6162) Warning: require() of ES modules is not supported.
require() of /home/travis/build/microlinkhq/metascraper/packages/metascraper-iframe/node_modules/oembed-parser/index.js from /home/travis/build/microlinkhq/metascraper/packages/metascraper-iframe/src/index.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename /home/travis/build/microlinkhq/metascraper/packages/metascraper-iframe/node_modules/oembed-parser/index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /home/travis/build/microlinkhq/metascraper/packages/metascraper-iframe/node_modules/oembed-parser/package.json.
/home/travis/build/microlinkhq/metascraper/packages/metascraper-iframe/node_modules/yargs/yargs.js:1163
      else throw err
           ^
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /home/travis/build/microlinkhq/metascraper/packages/metascraper-iframe/node_modules/oembed-parser/index.js
```

but actually the module is not written using imports, so this field looks innecessary.

Related: https://travis-ci.com/microlinkhq/metascraper/jobs/266852612#L368