### PR TITLE
add optional parameter argument to extract typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@
 //                 CodeBast4rd <https://github.com/CodeBast4rd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function extract(url: string): Promise<OembedData>;
+export function extract(url: string, params?: any): Promise<OembedData>;
 
 export function hasProvider(url: string): boolean;
 


### PR DESCRIPTION
The current typing does not specify the optional second argument for extract. I am not sure if maxwidth / maxheight / format are the only options, therefore I did not narrow the type down further.