### PR TITLE
Import .default from node-fetch

### DIFF
--- a/src/utils/fetchEmbed.js
+++ b/src/utils/fetchEmbed.js
@@ -1,6 +1,6 @@
 // utils -> fetchEmbed
 
-const fetch = require('node-fetch');
+const fetch = require('node-fetch').default;
 
 const fetchEmbed = async (url, provider, params = {}) => {
   const {

--- a/sync.js
+++ b/sync.js
@@ -7,7 +7,7 @@ const {
   writeFileSync,
 } = require('fs');
 
-const fetch = require('node-fetch');
+const fetch = require('node-fetch').default;
 
 const source = 'https://oembed.com/providers.json';
 const target = './src/utils/providers.json';


### PR DESCRIPTION
This change was implemented earlier in #27, but seems to have disappeared after switching to cross-fetch. The proposed change solves #26 for me.