### PR TITLE
Resync so schemes are properly updated

### DIFF
--- a/src/utils/providers.backup.json
+++ b/src/utils/providers.backup.json
@@ -12,6 +12,31 @@
     ]
   },
   {
+    "provider_name": "Abraia",
+    "provider_url": "https://abraia.me",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://store.abraia.me/*"
+        ],
+        "url": "https://api.abraia.me/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "ActBlue",
+    "provider_url": "https://secure.actblue.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://secure.actblue.com/donate/*"
+        ],
+        "url": "https://secure.actblue.com/cf/oembed"
+      }
+    ]
+  },
+  {
     "provider_name": "Adways",
     "provider_url": "http://www.adways.com",
     "endpoints": [
@@ -45,9 +70,10 @@
     "endpoints": [
       {
         "schemes": [
-          "https://app.altrulabs.com/*/*?answer_id=*"
+          "https://app.altrulabs.com/*/*?answer_id=*",
+          "https://app.altrulabs.com/player/*"
         ],
-        "url": "https://api.altrulabs.com/social/oembed",
+        "url": "https://api.altrulabs.com/api/v1/social/oembed",
         "formats": [
           "json"
         ]
@@ -107,6 +133,19 @@
     ]
   },
   {
+    "provider_name": "ArcGIS StoryMaps",
+    "provider_url": "https://storymaps.arcgis.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://storymaps.arcgis.com/stories/*"
+        ],
+        "url": "https://storymaps.arcgis.com/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Archivos",
     "provider_url": "https://app.archivos.digital",
     "endpoints": [
@@ -115,6 +154,24 @@
           "https://app.archivos.digital/app/view/*"
         ],
         "url": "https://app.archivos.digital/oembed/"
+      }
+    ]
+  },
+  {
+    "provider_name": "Audioboom",
+    "provider_url": "https://audioboom.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://audioboom.com/channels/*",
+          "https://audioboom.com/channel/*",
+          "https://audioboom.com/posts/*"
+        ],
+        "url": "https://audioboom.com/publishing/oembed/v4.{format}",
+        "formats": [
+          "json",
+          "xml"
+        ]
       }
     ]
   },
@@ -134,28 +191,43 @@
   },
   {
     "provider_name": "Audiomack",
-    "provider_url": "https://www.audiomack.com",
+    "provider_url": "https://audiomack.com",
     "endpoints": [
       {
         "schemes": [
-          "https://www.audiomack.com/song/*",
-          "https://www.audiomack.com/album/*",
-          "https://www.audiomack.com/playlist/*"
+          "https://audiomack.com/*/song/*",
+          "https://audiomack.com/*/album/*",
+          "https://audiomack.com/*/playlist/*"
         ],
-        "url": "https://www.audiomack.com/oembed",
+        "url": "https://audiomack.com/oembed",
         "discovery": true
       }
     ]
   },
   {
-    "provider_name": "AudioSnaps",
-    "provider_url": "http://audiosnaps.com",
+    "provider_name": "Avocode",
+    "provider_url": "https://www.avocode.com/",
     "endpoints": [
       {
         "schemes": [
-          "http://audiosnaps.com/k/*"
+          "https://app.avocode.com/view/*"
         ],
-        "url": "http://audiosnaps.com/service/oembed",
+        "url": "https://stage-embed.avocode.com/api/oembed",
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "AxiomNinja",
+    "provider_url": "http://axiom.ninja",
+    "endpoints": [
+      {
+        "schemes": [
+          "http://axiom.ninja/*"
+        ],
+        "url": "http://axiom.ninja/oembed/",
         "discovery": true
       }
     ]
@@ -167,10 +239,10 @@
       {
         "schemes": [
           "https://backtracks.fm/*/*/e/*",
-          "https://backtracks.fm/*",
-          "http://backtracks.fm/*",
           "https://backtracks.fm/*/s/*/*",
-          "https://backtracks.fm/*/*/*/*/e/*/*"
+          "https://backtracks.fm/*/*/*/*/e/*/*",
+          "https://backtracks.fm/*",
+          "http://backtracks.fm/*"
         ],
         "url": "https://backtracks.fm/oembed",
         "discovery": true
@@ -197,6 +269,20 @@
           "https://blackfire.io/profiles/compare/*/graph"
         ],
         "url": "https://blackfire.io/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Blogcast",
+    "provider_url": "https://blogcast.host/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://blogcast.host/embed/*",
+          "https://blogcast.host/embedly/*"
+        ],
+        "url": "https://blogcast.host/oembed",
         "discovery": true
       }
     ]
@@ -306,6 +392,22 @@
     ]
   },
   {
+    "provider_name": "Chainflix",
+    "provider_url": "https://chainflix.net",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://chainflix.net/video/*",
+          "https://chainflix.net/video/embed/*",
+          "https://*.chainflix.net/video/*",
+          "https://*.chainflix.net/video/embed/*"
+        ],
+        "url": "https://www.chainflix.net/video/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "ChartBlocks",
     "provider_url": "http://www.chartblocks.com/",
     "endpoints": [
@@ -372,6 +474,19 @@
     ]
   },
   {
+    "provider_name": "CoCo Corp",
+    "provider_url": "https://ilovecoco.video",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://app.ilovecoco.video/*/embed"
+        ],
+        "url": "https://app.ilovecoco.video/api/oembed.{format}",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "CodeHS",
     "provider_url": "http://www.codehs.com",
     "endpoints": [
@@ -393,7 +508,7 @@
           "http://codepen.io/*",
           "https://codepen.io/*"
         ],
-        "url": "http://codepen.io/api/oembed"
+        "url": "https://codepen.io/api/oembed"
       }
     ]
   },
@@ -477,6 +592,18 @@
     ]
   },
   {
+    "provider_name": "CustomerDB",
+    "provider_url": "http://customerdb.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://app.customerdb.com/share/*"
+        ],
+        "url": "https://app.customerdb.com/embed"
+      }
+    ]
+  },
+  {
     "provider_name": "Cyrano Systems",
     "provider_url": "http://www.cyranosystems.com/",
     "endpoints": [
@@ -494,21 +621,6 @@
     ]
   },
   {
-    "provider_name": "Daily Mile",
-    "provider_url": "http://www.dailymile.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "http://www.dailymile.com/people/*/entries/*"
-        ],
-        "url": "http://api.dailymile.com/oembed?format=json",
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
     "provider_name": "Dailymotion",
     "provider_url": "https://www.dailymotion.com",
     "endpoints": [
@@ -522,14 +634,27 @@
     ]
   },
   {
-    "provider_name": "Deseretnews.com",
-    "provider_url": "https://www.deseretnews.com",
+    "provider_name": "Datawrapper",
+    "provider_url": "http://www.datawrapper.de",
     "endpoints": [
       {
         "schemes": [
-          "https://*.deseretnews.com/*"
+          "https://datawrapper.dwcdn.net/*"
         ],
-        "url": "https://embed.deseretnews.com/"
+        "url": "https://api.datawrapper.de/v3/oembed/",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Deseret News",
+    "provider_url": "https://www.deseret.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.deseret.com/*"
+        ],
+        "url": "https://embed.deseret.com/"
       }
     ]
   },
@@ -539,13 +664,16 @@
     "endpoints": [
       {
         "schemes": [
+          "http://*.deviantart.com/art/*",
+          "http://*.deviantart.com/*#/d*",
+          "http://fav.me/*",
+          "http://sta.sh/*",
           "https://*.deviantart.com/art/*",
           "https://*.deviantart.com/*/art/*",
-          "http://fav.me/*",
-          "https://sta.sh/*",
-          "https://*.deviantart.com/*#/d*"
+          "https://sta.sh/*\",",
+          "https://*.deviantart.com/*#/d*\""
         ],
-        "url": "https://backend.deviantart.com/oembed"
+        "url": "http://backend.deviantart.com/oembed"
       }
     ]
   },
@@ -690,6 +818,19 @@
     ]
   },
   {
+    "provider_name": "Embedery",
+    "provider_url": "https://embedery.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://embedery.com/widget/*"
+        ],
+        "url": "https://embedery.com/api/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Embedly",
     "provider_url": "http://api.embed.ly/",
     "endpoints": [
@@ -726,38 +867,38 @@
     ]
   },
   {
-    "provider_name": "Facebook (Post)",
+    "provider_name": "Facebook",
     "provider_url": "https://www.facebook.com/",
     "endpoints": [
       {
         "schemes": [
           "https://www.facebook.com/*/posts/*",
-          "https://www.facebook.com/photos/*",
-          "https://www.facebook.com/*/photos/*",
-          "https://www.facebook.com/photo.php*",
-          "https://www.facebook.com/photo.php",
           "https://www.facebook.com/*/activity/*",
-          "https://www.facebook.com/permalink.php",
+          "https://www.facebook.com/photo.php?fbid=*",
+          "https://www.facebook.com/photos/*",
+          "https://www.facebook.com/permalink.php?story_fbid=*",
           "https://www.facebook.com/media/set?set=*",
           "https://www.facebook.com/questions/*",
           "https://www.facebook.com/notes/*/*/*"
         ],
-        "url": "https://www.facebook.com/plugins/post/oembed.json",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Facebook (Video)",
-    "provider_url": "https://www.facebook.com/",
-    "endpoints": [
+        "url": "https://graph.facebook.com/v8.0/oembed_post",
+        "discovery": false
+      },
       {
         "schemes": [
           "https://www.facebook.com/*/videos/*",
-          "https://www.facebook.com/video.php"
+          "https://www.facebook.com/video.php?id=*",
+          "https://www.facebook.com/video.php?v=*"
         ],
-        "url": "https://www.facebook.com/plugins/video/oembed.json",
-        "discovery": true
+        "url": "https://graph.facebook.com/v8.0/oembed_video",
+        "discovery": false
+      },
+      {
+        "schemes": [
+          "https://www.facebook.com/*"
+        ],
+        "url": "https://graph.facebook.com/v8.0/oembed_page",
+        "discovery": false
       }
     ]
   },
@@ -789,6 +930,20 @@
           "https://faithlifetv.com/media/resource/*/*"
         ],
         "url": "https://faithlifetv.com/api/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Firework",
+    "provider_url": "https://fireworktv.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.fireworktv.com/*",
+          "https://*.fireworktv.com/embed/*/v/*"
+        ],
+        "url": "https://www.fireworktv.com/oembed",
         "discovery": true
       }
     ]
@@ -847,18 +1002,6 @@
         ],
         "url": "https://app.flourish.studio/api/v1/oembed",
         "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Fontself",
-    "provider_url": "https://www.fontself.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://catapult.fontself.com/*"
-        ],
-        "url": "https://oembed.fontself.com/"
       }
     ]
   },
@@ -1049,10 +1192,56 @@
     "endpoints": [
       {
         "schemes": [
-          "https://hearthis.at/*/*/"
+          "https://hearthis.at/*/*/",
+          "https://hearthis.at/*/set/*/"
         ],
-        "url": "https://hearthis.at/oembed/",
+        "url": "https://hearthis.at/oembed/?format=json",
         "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "hihaho",
+    "provider_url": "https://www.hihaho.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://player.hihaho.com/*"
+        ],
+        "url": "https://player.hihaho.com/services/oembed/*",
+        "formats": [
+          "json",
+          "xml"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Homey",
+    "provider_url": "https://homey.app",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://homey.app/f/*",
+          "https://homey.app/*/flow/*"
+        ],
+        "url": "https://homey.app/api/oembed/flow",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Hosted by You",
+    "provider_url": "https://hostedbyyou.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://hostedbyyou.com/event/*"
+        ],
+        "url": "https://hostedbyyou.com/api/oembed",
+        "formats": [
+          "json"
+        ]
       }
     ]
   },
@@ -1106,6 +1295,19 @@
     ]
   },
   {
+    "provider_name": "iHeartRadio",
+    "provider_url": "https://www.iheart.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.iheart.com/podcast/*/*"
+        ],
+        "url": "https://www.iheart.com/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Indaco",
     "provider_url": "https://player.indacolive.com/",
     "endpoints": [
@@ -1122,13 +1324,13 @@
   },
   {
     "provider_name": "Infogram",
-    "provider_url": "https://infogr.am/",
+    "provider_url": "https://infogram.com/",
     "endpoints": [
       {
         "schemes": [
-          "https://infogr.am/*"
+          "https://infogram.com/*"
         ],
-        "url": "https://infogr.am/oembed"
+        "url": "https://infogram.com/oembed"
       }
     ]
   },
@@ -1193,6 +1395,10 @@
     "endpoints": [
       {
         "schemes": [
+          "http://instagram.com/*/p/*,",
+          "http://www.instagram.com/*/p/*,",
+          "https://instagram.com/*/p/*,",
+          "https://www.instagram.com/*/p/*,",
           "http://instagram.com/p/*",
           "http://instagr.am/p/*",
           "http://www.instagram.com/p/*",
@@ -1200,20 +1406,7 @@
           "https://instagram.com/p/*",
           "https://instagr.am/p/*",
           "https://www.instagram.com/p/*",
-          "https://www.instagr.am/*/p/*",
-          "http://instagram.com/*/p/*",
-          "http://instagr.am/*/p/*",
-          "http://www.instagram.com/*/p/*",
-          "http://www.instagr.am/*/p/*",
-          "https://instagram.com/*/p/*",
-          "https://instagr.am/*/p/*",
-          "https://www.instagram.com/*/p/*",
-          "https://www.instagr.am/*/p/*",
           "https://www.instagr.am/p/*",
-          "http://instagram.com/*/p/*,",
-          "http://www.instagram.com/*/p/*,",
-          "https://instagram.com/*/p/*,",
-          "https://www.instagram.com/*/p/*,",
           "http://instagram.com/tv/*",
           "http://instagr.am/tv/*",
           "http://www.instagram.com/tv/*",
@@ -1227,18 +1420,34 @@
         "formats": [
           "json"
         ]
-      }
-    ]
-  },
-  {
-    "provider_name": "iSnare Articles",
-    "provider_url": "https://www.isnare.com/",
-    "endpoints": [
+      },
       {
         "schemes": [
-          "https://www.isnare.com/*"
+          "http://instagram.com/*/p/*,",
+          "http://www.instagram.com/*/p/*,",
+          "https://instagram.com/*/p/*,",
+          "https://www.instagram.com/*/p/*,",
+          "http://instagram.com/p/*",
+          "http://instagr.am/p/*",
+          "http://www.instagram.com/p/*",
+          "http://www.instagr.am/p/*",
+          "https://instagram.com/p/*",
+          "https://instagr.am/p/*",
+          "https://www.instagram.com/p/*",
+          "https://www.instagr.am/p/*",
+          "http://instagram.com/tv/*",
+          "http://instagr.am/tv/*",
+          "http://www.instagram.com/tv/*",
+          "http://www.instagr.am/tv/*",
+          "https://instagram.com/tv/*",
+          "https://instagr.am/tv/*",
+          "https://www.instagram.com/tv/*",
+          "https://www.instagr.am/tv/*"
         ],
-        "url": "https://www.isnare.com/oembed/"
+        "url": "https://graph.facebook.com/v8.0/instagram_oembed",
+        "formats": [
+          "json"
+        ]
       }
     ]
   },
@@ -1261,6 +1470,24 @@
     "endpoints": [
       {
         "url": "https://music.ivlis.kr/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Jovian",
+    "provider_url": "https://jovian.ai/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://jovian.ml/*",
+          "https://jovian.ml/viewer*",
+          "https://*.jovian.ml/*",
+          "https://jovian.ai/*",
+          "https://jovian.ai/viewer*",
+          "https://*.jovian.ai/*"
+        ],
+        "url": "https://api.jovian.ai/oembed.json",
         "discovery": true
       }
     ]
@@ -1307,28 +1534,29 @@
     ]
   },
   {
-    "provider_name": "Kijk",
-    "provider_url": "https://www.kijk.nl/",
+    "provider_name": "Kirim.Email",
+    "provider_url": "https://kirim.email/",
     "endpoints": [
       {
         "schemes": [
-          "https://www.kijk.nl/video/*",
-          "https://www.kijk.nl/*/*/videos/*/*"
+          "https://halaman.email/form/*",
+          "https://aplikasi.kirim.email/form/*"
         ],
-        "url": "https://oembed.kijk.nl"
+        "url": "https://halaman.email/service/oembed",
+        "discovery": true
       }
     ]
   },
   {
     "provider_name": "Kit",
-    "provider_url": "https://kit.com/",
+    "provider_url": "https://kit.co/",
     "endpoints": [
       {
         "schemes": [
-          "http://kit.com/*/*",
-          "https://kit.com/*/*"
+          "http://kit.co/*/*",
+          "https://kit.co/*/*"
         ],
-        "url": "https://embed.kit.com/oembed",
+        "url": "https://embed.kit.co/oembed",
         "discovery": true
       }
     ]
@@ -1347,6 +1575,19 @@
     ]
   },
   {
+    "provider_name": "kmdr",
+    "provider_url": "https://kmdr.sh",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://app.kmdr.sh/h/*",
+          "https://app.kmdr.sh/history/*"
+        ],
+        "url": "https://api.kmdr.sh/services/oembed"
+      }
+    ]
+  },
+  {
     "provider_name": "Knacki",
     "provider_url": "http://jdr.knacki.info",
     "endpoints": [
@@ -1360,6 +1601,21 @@
     ]
   },
   {
+    "provider_name": "Knowledge Pad",
+    "provider_url": "https://knowledgepad.co/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://knowledgepad.co/#/knowledge/*"
+        ],
+        "url": "https://api.spoonacular.com/knowledge/oembed",
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
     "provider_name": "LearningApps.org",
     "provider_url": "http://learningapps.org/",
     "endpoints": [
@@ -1368,6 +1624,19 @@
           "http://learningapps.org/*"
         ],
         "url": "http://learningapps.org/oembed.php",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "LeMans.Pod",
+    "provider_url": "https://umotion-test.univ-lemans.fr/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://umotion-test.univ-lemans.fr/video/*"
+        ],
+        "url": "https://umotion-test.univ-lemans.fr/oembed",
         "discovery": true
       }
     ]
@@ -1420,6 +1689,19 @@
     ]
   },
   {
+    "provider_name": "Lumiere",
+    "provider_url": "https://latd.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.lumiere.is/v/*"
+        ],
+        "url": "https://admin.lumiere.is/api/services/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "MathEmbed",
     "provider_url": "http://mathembed.com",
     "endpoints": [
@@ -1459,6 +1741,24 @@
     ]
   },
   {
+    "provider_name": "MediaLab",
+    "provider_url": "https://www.medialab.co/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.medialab.app/share/watch/*",
+          "https://*.medialab.co/share/watch/*",
+          "https://*.medialab.app/share/social/*",
+          "https://*.medialab.co/share/social/*",
+          "https://*.medialab.app/share/embed/*",
+          "https://*.medialab.co/share/embed/*"
+        ],
+        "url": "https://*.medialab.(co|app)/api/oembed/",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Medienarchiv der Künste - Zürcher Hochschule der Künste",
     "provider_url": "https://medienarchiv.zhdk.ch/",
     "endpoints": [
@@ -1486,6 +1786,43 @@
         "formats": [
           "json"
         ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Mermaid Ink",
+    "provider_url": "https://mermaid.ink",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://mermaid.ink/img/*",
+          "https://mermaid.ink/svg/*"
+        ],
+        "url": "https://mermaid.ink/services/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Microlink",
+    "provider_url": "http://api.microlink.io",
+    "endpoints": [
+      {
+        "url": "https://api.microlink.io"
+      }
+    ]
+  },
+  {
+    "provider_name": "Microsoft Stream",
+    "provider_url": "https://stream.microsoft.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.microsoftstream.com/video/*",
+          "https://*.microsoftstream.com/channel/*"
+        ],
+        "url": "https://web.microsoftstream.com/oembed",
+        "discovery": true
       }
     ]
   },
@@ -1573,6 +1910,23 @@
     ]
   },
   {
+    "provider_name": "Namchey",
+    "provider_url": "https://namchey.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://namchey.com/embeds/*"
+        ],
+        "url": "https://namchey.com/api/oembed",
+        "formats": [
+          "json",
+          "xml"
+        ],
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "nanoo.tv",
     "provider_url": "https://www.nanoo.tv/",
     "endpoints": [
@@ -1610,6 +1964,25 @@
     ]
   },
   {
+    "provider_name": "Natural Atlas",
+    "provider_url": "https://naturalatlas.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://naturalatlas.com/*",
+          "https://naturalatlas.com/*/*",
+          "https://naturalatlas.com/*/*/*",
+          "https://naturalatlas.com/*/*/*/*"
+        ],
+        "url": "https://naturalatlas.com/oembed.{format}",
+        "discovery": true,
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
     "provider_name": "nfb.ca",
     "provider_url": "http://www.nfb.ca/",
     "endpoints": [
@@ -1623,6 +1996,36 @@
     ]
   },
   {
+    "provider_name": "NoPaste",
+    "provider_url": "https://nopaste.ml",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://nopaste.ml/*"
+        ],
+        "url": "https://oembed.nopaste.ml",
+        "discovery": false
+      }
+    ]
+  },
+  {
+    "provider_name": "Observable",
+    "provider_url": "https://observablehq.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://observablehq.com/@*/*",
+          "https://observablehq.com/d/*",
+          "https://observablehq.com/embed/*"
+        ],
+        "url": "https://api.observablehq.com/oembed",
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
     "provider_name": "Odds.com.au",
     "provider_url": "https://www.odds.com.au",
     "endpoints": [
@@ -1632,6 +2035,28 @@
           "https://odds.com.au/*"
         ],
         "url": "https://www.odds.com.au/api/oembed/"
+      }
+    ]
+  },
+  {
+    "provider_name": "Odesli (formerly Songlink)",
+    "provider_url": "https://odesli.co",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://song.link/*",
+          "https://album.link/*",
+          "https://artist.link/*",
+          "https://playlist.link/*",
+          "https://pods.link/*",
+          "https://mylink.page/*",
+          "https://odesli.co/*"
+        ],
+        "url": "https://song.link/oembed",
+        "formats": [
+          "json"
+        ],
+        "discovery": true
       }
     ]
   },
@@ -1748,6 +2173,35 @@
     ]
   },
   {
+    "provider_name": "OZ",
+    "provider_url": "https://www.oz.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.oz.com/*/video/*"
+        ],
+        "url": "https://core.oz.com/oembed",
+        "formats": [
+          "json",
+          "xml"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Padlet",
+    "provider_url": "https://padlet.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://padlet.com/*"
+        ],
+        "url": "https://padlet.com/oembed/",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Pastery",
     "provider_url": "https://www.pastery.net",
     "endpoints": [
@@ -1770,6 +2224,23 @@
       {
         "url": "https://beta.pingvp.com.kpnis.nl/p/oembed.php",
         "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Pinpoll",
+    "provider_url": "https://www.pinpoll.com/products/tools",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://tools.pinpoll.com/embed/*"
+        ],
+        "url": "https://tools.pinpoll.com/oembed",
+        "discovery": true,
+        "formats": [
+          "json",
+          "xml"
+        ]
       }
     ]
   },
@@ -1801,6 +2272,19 @@
           "http://*.podbean.com/e/*"
         ],
         "url": "https://api.podbean.com/v1/oembed"
+      }
+    ]
+  },
+  {
+    "provider_name": "Polaris Share",
+    "provider_url": "https://www.polarishare.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.polarishare.com/*/*"
+        ],
+        "url": "https://api.polarishare.com/rest/api/oembed",
+        "discovery": true
       }
     ]
   },
@@ -1843,6 +2327,29 @@
     ]
   },
   {
+    "provider_name": "posiXion",
+    "provider_url": "https://posixion.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://posixion.com/question/*",
+          "https://posixion.com/*/question/*"
+        ],
+        "url": "http://posixion.com/services/oembed/"
+      }
+    ]
+  },
+  {
+    "provider_name": "Qualifio",
+    "provider_url": "https://qualifio.com/",
+    "endpoints": [
+      {
+        "url": "https://oembed.qualifio.com/",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Quiz.biz",
     "provider_url": "http://www.quiz.biz/",
     "endpoints": [
@@ -1869,14 +2376,37 @@
     ]
   },
   {
-    "provider_name": "RapidEngage",
-    "provider_url": "https://rapidengage.com",
+    "provider_name": "RadioPublic",
+    "provider_url": "https://radiopublic.com",
     "endpoints": [
       {
         "schemes": [
-          "https://rapidengage.com/s/*"
+          "https://play.radiopublic.com/*",
+          "https://radiopublic.com/*",
+          "https://www.radiopublic.com/*",
+          "http://play.radiopublic.com/*",
+          "http://radiopublic.com/*",
+          "http://www.radiopublic.com/*",
+          "https://*.radiopublic.com/*'"
         ],
-        "url": "https://rapidengage.com/api/oembed"
+        "url": "https://oembed.radiopublic.com/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "rcvis",
+    "provider_url": "https://www.rcvis.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.rcvis.com/v/*",
+          "https://www.rcvis.com/visualize=*",
+          "https://www.rcvis.com/ve/*",
+          "https://www.rcvis.com/visualizeEmbedded=*"
+        ],
+        "url": "https://animatron.com/oembed",
+        "discovery": true
       }
     ]
   },
@@ -1992,6 +2522,34 @@
       {
         "url": "https://rumble.com/api/Media/oembed.{format}",
         "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Runkit",
+    "provider_url": "https://runkit.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "http://embed.runkit.com/*,",
+          "https://embed.runkit.com/*,"
+        ],
+        "url": "https://embed.runkit.com/oembed",
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Saooti",
+    "provider_url": "https://octopus.saooti.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://octopus.saooti.com/main/pub/podcast/*"
+        ],
+        "url": "https://octopus.saooti.com/oembed"
       }
     ]
   },
@@ -2114,6 +2672,20 @@
     ]
   },
   {
+    "provider_name": "Show by Animaker",
+    "provider_url": "https://getshow.io/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://app.getshow.io/iframe/*",
+          "https://*.getshow.io/share/*"
+        ],
+        "url": "https://api.getshow.io/oembed.{format}",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Show the Way, actionable location info",
     "provider_url": "https://showtheway.io",
     "endpoints": [
@@ -2177,26 +2749,46 @@
     "endpoints": [
       {
         "schemes": [
+          "https://www.slideshare.net/*/*",
           "http://www.slideshare.net/*/*",
+          "https://fr.slideshare.net/*/*",
           "http://fr.slideshare.net/*/*",
+          "https://de.slideshare.net/*/*",
           "http://de.slideshare.net/*/*",
+          "https://es.slideshare.net/*/*",
           "http://es.slideshare.net/*/*",
+          "https://pt.slideshare.net/*/*",
           "http://pt.slideshare.net/*/*"
         ],
-        "url": "http://www.slideshare.net/api/oembed/2",
+        "url": "https://www.slideshare.net/api/oembed/2",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "SmashNotes",
+    "provider_url": "https://smashnotes.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://smashnotes.com/p/*",
+          "https://smashnotes.com/p/*/e/* - https://smashnotes.com/p/*/e/*/s/*"
+        ],
+        "url": "https://smashnotes.com/services/oembed",
         "discovery": true
       }
     ]
   },
   {
     "provider_name": "SmugMug",
-    "provider_url": "http://www.smugmug.com/",
+    "provider_url": "https://www.smugmug.com/",
     "endpoints": [
       {
         "schemes": [
-          "http://*.smugmug.com/*"
+          "http://*.smugmug.com/*",
+          "https://*.smugmug.com/*"
         ],
-        "url": "http://api.smugmug.com/services/oembed/",
+        "url": "https://api.smugmug.com/services/oembed/",
         "discovery": true
       }
     ]
@@ -2218,22 +2810,6 @@
     ]
   },
   {
-    "provider_name": "Songlink",
-    "provider_url": "https://song.link",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://song.link/*"
-        ],
-        "url": "https://song.link/oembed",
-        "formats": [
-          "json"
-        ],
-        "discovery": true
-      }
-    ]
-  },
-  {
     "provider_name": "SoundCloud",
     "provider_url": "http://soundcloud.com/",
     "endpoints": [
@@ -2244,24 +2820,6 @@
           "https://soundcloud.app.goog.gl/*"
         ],
         "url": "https://soundcloud.com/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "Soundsgood",
-    "provider_url": "https://soundsgood.co",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://play.soundsgood.co/playlist/*",
-          "https://soundsgood.co/playlist/*"
-        ],
-        "url": "https://play.soundsgood.co/oembed",
-        "discovery": true,
-        "formats": [
-          "json",
-          "xml"
-        ]
       }
     ]
   },
@@ -2363,6 +2921,35 @@
     ]
   },
   {
+    "provider_name": "Subscribi",
+    "provider_url": "https://subscribi.io/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://subscribi.io/api/oembed*"
+        ],
+        "url": "https://subscribi.io/api/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Sudomemo",
+    "provider_url": "https://www.sudomemo.net/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.sudomemo.net/watch/*",
+          "http://www.sudomemo.net/watch/*",
+          "https://flipnot.es/*",
+          "http://flipnot.es/*"
+        ],
+        "url": "https://www.sudomemo.net/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Sutori",
     "provider_url": "https://www.sutori.com/",
     "endpoints": [
@@ -2393,8 +2980,8 @@
     ]
   },
   {
-    "provider_name": "Ted",
-    "provider_url": "https://ted.com",
+    "provider_name": "TED",
+    "provider_url": "https://www.ted.com",
     "endpoints": [
       {
         "schemes": [
@@ -2402,7 +2989,8 @@
           "https://ted.com/talks/*",
           "https://www.ted.com/talks/*"
         ],
-        "url": "https://www.ted.com/talks/oembed.{format}"
+        "url": "https://www.ted.com/services/v1/oembed.{format}",
+        "discovery": true
       }
     ]
   },
@@ -2455,6 +3043,18 @@
     ]
   },
   {
+    "provider_name": "TikTok",
+    "provider_url": "http://www.tiktok.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.tiktok.com/*/video/*"
+        ],
+        "url": "https://www.tiktok.com/oembed"
+      }
+    ]
+  },
+  {
     "provider_name": "Toornament",
     "provider_url": "https://www.toornament.com/",
     "endpoints": [
@@ -2488,6 +3088,34 @@
     ]
   },
   {
+    "provider_name": "TourHero",
+    "provider_url": "http://www.tourhero.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.tourhero.com/*"
+        ],
+        "url": "https://oembed.tourhero.com/",
+        "discovery": true,
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Tumblr",
+    "provider_url": "https://www.tumblr.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.tumblr.com/post/*"
+        ],
+        "url": "https://www.tumblr.com/oembed/1.0"
+      }
+    ]
+  },
+  {
     "provider_name": "Tuxx",
     "provider_url": "https://www.tuxx.be/",
     "endpoints": [
@@ -2506,9 +3134,10 @@
     "endpoints": [
       {
         "schemes": [
-          "http://www.tvcf.co.kr/v/*"
+          "https://play.tvcf.co.kr/*",
+          "https://*.tvcf.co.kr/*"
         ],
-        "url": "http://www.tvcf.co.kr/services/oembed"
+        "url": "https://play.tvcf.co.kr/rest/oembed"
       }
     ]
   },
@@ -2524,6 +3153,30 @@
           "https://*.twitter.com/*/moments/*"
         ],
         "url": "https://publish.twitter.com/oembed"
+      }
+    ]
+  },
+  {
+    "provider_name": "TypeCast",
+    "provider_url": "https://typecast.ai",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://play.typecast.ai/s/*",
+          "https://play.typecast.ai/e/*",
+          "https://play.typecast.ai/*"
+        ],
+        "url": "https://play.typecast.ai/oembed"
+      }
+    ]
+  },
+  {
+    "provider_name": "Typlog",
+    "provider_url": "https://typlog.com",
+    "endpoints": [
+      {
+        "url": "https://typlog.com/oembed",
+        "discovery": true
       }
     ]
   },
@@ -2555,6 +3208,19 @@
     ]
   },
   {
+    "provider_name": "UnivParis1.Pod",
+    "provider_url": "https://mediatheque.univ-paris1.fr/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://mediatheque.univ-paris1.fr/video/*"
+        ],
+        "url": "https://mediatheque.univ-paris1.fr/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "UOL",
     "provider_url": "https://mais.uol.com.br/",
     "endpoints": [
@@ -2569,6 +3235,19 @@
     ]
   },
   {
+    "provider_name": "uppy",
+    "provider_url": "https://uppy.jp",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://app.uppy.jp/_shares/video/*"
+        ],
+        "url": "https://api.uppy.jp/v1/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Ustream",
     "provider_url": "http://www.ustream.tv",
     "endpoints": [
@@ -2578,6 +3257,23 @@
           "http://*.ustream.com/*"
         ],
         "url": "http://www.ustream.tv/oembed",
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "uStudio, Inc.",
+    "provider_url": "https://www.ustudio.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.ustudio.com/embed/*",
+          "https://*.ustudio.com/embed/*/*"
+        ],
+        "url": "https://app.ustudio.com/api/v2/oembed",
+        "discovery": true,
         "formats": [
           "json"
         ]
@@ -2690,7 +3386,6 @@
     "endpoints": [
       {
         "schemes": [
-          "https://players.vidmizer.com/*",
           "https://players-cdn-v2.vidmizer.com/*"
         ],
         "url": "https://app-v2.vidmizer.com/api/oembed",
@@ -2700,16 +3395,13 @@
   },
   {
     "provider_name": "Vidyard",
-    "provider_url": "http://www.vidyard.com",
+    "provider_url": "https://vidyard.com",
     "endpoints": [
       {
         "schemes": [
-          "http://embed.vidyard.com/*",
-          "http://play.vidyard.com/*",
-          "http://share.vidyard.com/*",
-          "http://*.hubs.vidyard.com/*",
           "http://*.vidyard.com/*",
           "https://*.vidyard.com/*",
+          "http://*.hubs.vidyard.com/*",
           "https://*.hubs.vidyard.com/*"
         ],
         "url": "https://api.vidyard.com/dashboard/v1.1/oembed",
@@ -2736,6 +3428,23 @@
     ]
   },
   {
+    "provider_name": "Viously",
+    "provider_url": "https://www.viously.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.viously.com/*/*"
+        ],
+        "url": "https://www.viously.com/oembed",
+        "discovery": true,
+        "formats": [
+          "json",
+          "xml"
+        ]
+      }
+    ]
+  },
+  {
     "provider_name": "Viziosphere",
     "provider_url": "http://www.viziosphere.com",
     "endpoints": [
@@ -2745,6 +3454,18 @@
         ],
         "url": "http://viziosphere.com/services/oembed/",
         "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Vizydrop",
+    "provider_url": "https://vizydrop.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://vizydrop.com/shared/*"
+        ],
+        "url": "https://vizydrop.com/oembed"
       }
     ]
   },
@@ -2807,6 +3528,20 @@
     ]
   },
   {
+    "provider_name": "Wave.video",
+    "provider_url": "https://wave.video",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://watch.wave.video/*",
+          "https://embed.wave.video/*"
+        ],
+        "url": "https://embed.wave.video/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "wecandeo",
     "provider_url": "http://www.wecandeo.com/",
     "endpoints": [
@@ -2864,6 +3599,35 @@
     ]
   },
   {
+    "provider_name": "Wokwi",
+    "provider_url": "https://wokwi.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://wokwi.com/share/*"
+        ],
+        "url": "https://wokwi.com/api/oembed",
+        "discovery": true,
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Wolfram Cloud",
+    "provider_url": "https://www.wolframcloud.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.wolframcloud.com/*"
+        ],
+        "url": "https://www.wolframcloud.com/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Wootled",
     "provider_url": "http://www.wootled.com/",
     "endpoints": [
@@ -2879,6 +3643,22 @@
       {
         "url": "http://public-api.wordpress.com/oembed/",
         "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Xpression",
+    "provider_url": "https://web.xpression.jp",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://web.xpression.jp/video/*"
+        ],
+        "url": "https://web.xpression.jp/api/oembed",
+        "formats": [
+          "json",
+          "xml"
+        ]
       }
     ]
   },
@@ -2922,763 +3702,11 @@
       {
         "schemes": [
           "https://*.youtube.com/watch*",
-          "https://*.youtube.com/v/*\"",
-          "https://youtu.be/*",
-          "https://*.youtube.com/v/*"
+          "https://*.youtube.com/v/*",
+          "https://youtu.be/*"
         ],
         "url": "https://www.youtube.com/oembed",
         "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "ZnipeTV",
-    "provider_url": "https://www.znipe.tv/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.znipe.tv/*"
-        ],
-        "url": "https://api.znipe.tv/v3/oembed/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "ZProvider",
-    "provider_url": "https://reports.zoho.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://reports.zoho.com/ZDBDataSheetView.cc?OBJID=1432535000000003002&STANDALONE=true&INTERVAL=120&DATATYPESYMBOL=false&REMTOOLBAR=false&SEARCHBOX=true&INCLUDETITLE=true&INCLUDEDESC=true&SHOWHIDEOPT=true"
-        ],
-        "url": "http://api.provider.com/oembed.json",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Namchey",
-    "provider_url": "https://namchey.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://namchey.com/embeds/*"
-        ],
-        "url": "https://namchey.com/api/oembed",
-        "formats": [
-          "json",
-          "xml"
-        ],
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Natural Atlas",
-    "provider_url": "https://naturalatlas.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://naturalatlas.com/*",
-          "https://naturalatlas.com/*/*",
-          "https://naturalatlas.com/*/*/*",
-          "https://naturalatlas.com/*/*/*/*"
-        ],
-        "url": "https://naturalatlas.com/oembed.{format}",
-        "discovery": true,
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "posiXion",
-    "provider_url": "https://posixion.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://posixion.com/question/*",
-          "https://posixion.com/*/question/*"
-        ],
-        "url": "http://posixion.com/services/oembed/"
-      }
-    ]
-  },
-  {
-    "provider_name": "SmashNotes",
-    "provider_url": "https://smashnotes.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://smashnotes.com/p/*",
-          "https://smashnotes.com/p/*/e/* - https://smashnotes.com/p/*/e/*/s/*"
-        ],
-        "url": "https://smashnotes.com/services/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "TypeCast",
-    "provider_url": "https://typecast.ai",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://play.typecast.ai/s/*",
-          "https://play.typecast.ai/e/*",
-          "https://play.typecast.ai/*"
-        ],
-        "url": "https://play.typecast.ai/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "Audioboom",
-    "provider_url": "https://audioboom.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://audioboom.com/channel/*",
-          "https://audioboom.com/posts/*",
-          "https://audioboom.com/channels/*"
-        ],
-        "url": "https://audioboom.com/publishing/oembed/v4.{format}",
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Blogcast",
-    "provider_url": "https://blogcast.host/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://blogcast.host/embed/*",
-          "https://blogcast.host/embedly/*"
-        ],
-        "url": "https://blogcast.host/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Facebook",
-    "provider_url": "https://www.facebook.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.facebook.com/*/posts/*",
-          "https://www.facebook.com/photos/*",
-          "https://www.facebook.com/*/photos/*",
-          "https://www.facebook.com/photo.php*",
-          "https://www.facebook.com/photo.php",
-          "https://www.facebook.com/*/activity/*",
-          "https://www.facebook.com/permalink.php",
-          "https://www.facebook.com/media/set?set=*",
-          "https://www.facebook.com/questions/*",
-          "https://www.facebook.com/notes/*/*/*"
-        ],
-        "url": "https://www.facebook.com/plugins/post/oembed.json",
-        "discovery": true
-      },
-      {
-        "schemes": [
-          "https://www.facebook.com/*/videos/*",
-          "https://www.facebook.com/video.php"
-        ],
-        "url": "https://www.facebook.com/plugins/video/oembed.json",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "OZ",
-    "provider_url": "https://www.oz.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.oz.com/*/video/*"
-        ],
-        "url": "https://core.oz.com/oembed",
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Polaris Share",
-    "provider_url": "https://www.polarishare.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.polarishare.com/*/*"
-        ],
-        "url": "https://api.polarishare.com/rest/api/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Typlog",
-    "provider_url": "https://typlog.com",
-    "endpoints": [
-      {
-        "url": "https://typlog.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "uStudio, Inc.",
-    "provider_url": "https://www.ustudio.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.ustudio.com/embed/*",
-          "https://*.ustudio.com/embed/*/*"
-        ],
-        "url": "https://app.ustudio.com/api/v2/oembed",
-        "discovery": true,
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Abraia",
-    "provider_url": "https://abraia.me",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://store.abraia.me/*"
-        ],
-        "url": "https://api.abraia.me/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "ArcGIS StoryMaps",
-    "provider_url": "https://storymaps.arcgis.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://storymaps.arcgis.com/stories/*"
-        ],
-        "url": "https://storymaps.arcgis.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Avocode",
-    "provider_url": "https://www.avocode.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://app.avocode.com/view/*"
-        ],
-        "url": "https://stage-embed.avocode.com/api/oembed",
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Deseret News",
-    "provider_url": "https://www.deseret.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.deseret.com/*"
-        ],
-        "url": "https://embed.deseret.com/"
-      }
-    ]
-  },
-  {
-    "provider_name": "Firework",
-    "provider_url": "https://fireworktv.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.fireworktv.com/*",
-          "https://*.fireworktv.com/embed/*/v/*"
-        ],
-        "url": "https://www.fireworktv.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Homey",
-    "provider_url": "https://homey.app",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://homey.app/f/*",
-          "https://homey.app/*/flow/*"
-        ],
-        "url": "https://homey.app/api/oembed/flow",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "iHeartRadio",
-    "provider_url": "https://www.iheart.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.iheart.com/podcast/*/*"
-        ],
-        "url": "https://www.iheart.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Jovian",
-    "provider_url": "https://jovian.ml/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://jovian.ml/*",
-          "https://jovian.ml/viewer*",
-          "https://*.jovian.ml/*"
-        ],
-        "url": "https://api.jovian.ai/oembed.json",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Kirim.Email",
-    "provider_url": "https://kirim.email/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://halaman.email/form/*",
-          "https://aplikasi.kirim.email/form/*"
-        ],
-        "url": "https://halaman.email/service/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "MediaLab",
-    "provider_url": "https://www.medialab.co/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.medialab.app/share/watch/*",
-          "https://*.medialab.co/share/watch/*",
-          "https://*.medialab.app/share/social/*",
-          "https://*.medialab.co/share/social/*",
-          "https://*.medialab.app/share/embed/*",
-          "https://*.medialab.co/share/embed/*"
-        ],
-        "url": "https://*.medialab.(co|app)/api/oembed/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Mermaid Ink",
-    "provider_url": "https://mermaid.ink",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://mermaid.ink/img/*",
-          "https://mermaid.ink/svg/*"
-        ],
-        "url": "https://mermaid.ink/services/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Microlink",
-    "provider_url": "http://api.microlink.io",
-    "endpoints": [
-      {
-        "url": "https://api.microlink.io"
-      }
-    ]
-  },
-  {
-    "provider_name": "TED",
-    "provider_url": "https://www.ted.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "http://ted.com/talks/*",
-          "https://ted.com/talks/*",
-          "https://www.ted.com/talks/*"
-        ],
-        "url": "https://www.ted.com/services/v1/oembed.{format}",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "UnivParis1.Pod",
-    "provider_url": "https://mediatheque.univ-paris1.fr/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://mediatheque.univ-paris1.fr/video/*"
-        ],
-        "url": "https://mediatheque.univ-paris1.fr/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Viously",
-    "provider_url": "https://www.viously.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.viously.com/*/*"
-        ],
-        "url": "https://www.viously.com/oembed",
-        "discovery": true,
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Vizydrop",
-    "provider_url": "https://vizydrop.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://vizydrop.com/shared/*"
-        ],
-        "url": "https://vizydrop.com/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "Xpression",
-    "provider_url": "https://web.xpression.jp",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://web.xpression.jp/video/*"
-        ],
-        "url": "https://web.xpression.jp/api/oembed",
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "ZingSoft",
-    "provider_url": "https://app.zingsoft.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://app.zingsoft.com/embed/*",
-          "https://app.zingsoft.com/view/*"
-        ],
-        "url": "https://app.zingsoft.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Zoomable",
-    "provider_url": "https://zoomable.ca/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://srv2.zoomable.ca/viewer.php*"
-        ],
-        "url": "https://srv2.zoomable.ca/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "AxiomNinja",
-    "provider_url": "http://axiom.ninja",
-    "endpoints": [
-      {
-        "schemes": [
-          "http://axiom.ninja/*"
-        ],
-        "url": "http://axiom.ninja/oembed/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Chainflix",
-    "provider_url": "https://chainflix.net",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://chainflix.net/video/*",
-          "https://chainflix.net/video/embed/*",
-          "https://*.chainflix.net/video/*",
-          "https://*.chainflix.net/video/embed/*"
-        ],
-        "url": "https://beta.chainflix.net/video/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "CoCo Corp",
-    "provider_url": "https://ilovecoco.video",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://app.ilovecoco.video/*/embed"
-        ],
-        "url": "https://app.ilovecoco.video/api/oembed.{format}",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Datawrapper",
-    "provider_url": "http://www.datawrapper.de",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://datawrapper.dwcdn.net/*"
-        ],
-        "url": "https://api.datawrapper.de/v3/oembed/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Embedery",
-    "provider_url": "https://embedery.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://embedery.com/widget/*"
-        ],
-        "url": "https://embedery.com/api/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "hihaho",
-    "provider_url": "https://www.hihaho.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://player.hihaho.com/*"
-        ],
-        "url": "https://player.hihaho.com/services/oembed/*",
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Knowledge Pad",
-    "provider_url": "https://knowledgepad.co/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://knowledgepad.co/#/knowledge/*"
-        ],
-        "url": "https://api.spoonacular.com/knowledge/oembed",
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "LeMans.Pod",
-    "provider_url": "https://umotion-test.univ-lemans.fr/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://umotion-test.univ-lemans.fr/video/*"
-        ],
-        "url": "https://umotion-test.univ-lemans.fr/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Microsoft Stream",
-    "provider_url": "https://stream.microsoft.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.microsoftstream.com/video/*",
-          "https://*.microsoftstream.com/channel/*"
-        ],
-        "url": "https://web.microsoftstream.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Odesli (formerly Songlink)",
-    "provider_url": "https://odesli.co",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://song.link/*",
-          "https://album.link/*",
-          "https://artist.link/*",
-          "https://playlist.link/*",
-          "https://pods.link/*",
-          "https://mylink.page/*",
-          "https://odesli.co/*"
-        ],
-        "url": "https://song.link/oembed",
-        "formats": [
-          "json"
-        ],
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Padlet",
-    "provider_url": "https://padlet.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://padlet.com/*"
-        ],
-        "url": "https://padlet.com/oembed/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Pinpoll",
-    "provider_url": "https://www.pinpoll.com/products/tools",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://tools.pinpoll.com/embed/*"
-        ],
-        "url": "https://tools.pinpoll.com/oembed",
-        "discovery": true,
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Qualifio",
-    "provider_url": "https://qualifio.com/",
-    "endpoints": [
-      {
-        "url": "https://oembed.qualifio.com/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "RadioPublic",
-    "provider_url": "https://radiopublic.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://play.radiopublic.com/*",
-          "https://radiopublic.com/*",
-          "https://www.radiopublic.com/*",
-          "http://play.radiopublic.com/*",
-          "http://radiopublic.com/*",
-          "http://www.radiopublic.com/*",
-          "https://*.radiopublic.com/*'"
-        ],
-        "url": "https://oembed.radiopublic.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Runkit",
-    "provider_url": "https://runkit.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "http://embed.runkit.com/*,",
-          "https://embed.runkit.com/*,"
-        ],
-        "url": "https://embed.runkit.com/oembed",
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "TikTok",
-    "provider_url": "http://www.tiktok.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.tiktok.com/*/video/*",
-          "https://m.tiktok.com/v/*"
-        ],
-        "url": "https://www.tiktok.com/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "Wave.video",
-    "provider_url": "https://wave.video",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://watch.wave.video/*",
-          "https://embed.wave.video/*"
-        ],
-        "url": "https://embed.wave.video/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Wokwi",
-    "provider_url": "https://wokwi.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://wokwi.com/share/*"
-        ],
-        "url": "https://wokwi.com/api/oembed",
-        "discovery": true,
-        "formats": [
-          "json"
-        ]
       }
     ]
   },
@@ -3699,126 +3727,41 @@
     ]
   },
   {
-    "provider_name": "Lumiere",
-    "provider_url": "https://latd.com",
+    "provider_name": "ZingSoft",
+    "provider_url": "https://app.zingsoft.com",
     "endpoints": [
       {
         "schemes": [
-          "https://*.lumiere.is/v/*"
+          "https://app.zingsoft.com/embed/*",
+          "https://app.zingsoft.com/view/*"
         ],
-        "url": "https://admin.lumiere.is/api/services/oembed",
+        "url": "https://app.zingsoft.com/oembed",
         "discovery": true
       }
     ]
   },
   {
-    "provider_name": "NoPaste",
-    "provider_url": "https://nopaste.ml",
+    "provider_name": "ZnipeTV",
+    "provider_url": "https://www.znipe.tv/",
     "endpoints": [
       {
         "schemes": [
-          "https://nopaste.ml/*"
+          "https://*.znipe.tv/*"
         ],
-        "url": "https://oembed.nopaste.ml",
-        "discovery": false
-      }
-    ]
-  },
-  {
-    "provider_name": "Observable",
-    "provider_url": "https://observablehq.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://observablehq.com/@*/*",
-          "https://observablehq.com/d/*",
-          "https://observablehq.com/embed/*"
-        ],
-        "url": "https://api.observablehq.com/oembed",
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "rcvis",
-    "provider_url": "https://www.rcvis.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.rcvis.com/v/*",
-          "https://www.rcvis.com/visualize=*",
-          "https://www.rcvis.com/ve/*",
-          "https://www.rcvis.com/visualizeEmbedded=*"
-        ],
-        "url": "https://animatron.com/oembed",
+        "url": "https://api.znipe.tv/v3/oembed/",
         "discovery": true
       }
     ]
   },
   {
-    "provider_name": "Saooti",
-    "provider_url": "https://octopus.saooti.com",
+    "provider_name": "Zoomable",
+    "provider_url": "https://zoomable.ca/",
     "endpoints": [
       {
         "schemes": [
-          "https://octopus.saooti.com/main/pub/podcast/*"
+          "https://srv2.zoomable.ca/viewer.php*"
         ],
-        "url": "https://octopus.saooti.com/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "Subscribi",
-    "provider_url": "https://subscribi.io/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://subscribi.io/api/oembed*"
-        ],
-        "url": "https://subscribi.io/api/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "TourHero",
-    "provider_url": "http://www.tourhero.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.tourhero.com/*"
-        ],
-        "url": "https://oembed.tourhero.com/",
-        "discovery": true,
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Tumblr",
-    "provider_url": "https://www.tumblr.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.tumblr.com/post/*"
-        ],
-        "url": "https://www.tumblr.com/oembed/1.0"
-      }
-    ]
-  },
-  {
-    "provider_name": "Wolfram Cloud",
-    "provider_url": "https://www.wolframcloud.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.wolframcloud.com/*"
-        ],
-        "url": "https://www.wolframcloud.com/oembed",
+        "url": "https://srv2.zoomable.ca/oembed",
         "discovery": true
       }
     ]

--- a/src/utils/providers.json
+++ b/src/utils/providers.json
@@ -12,6 +12,31 @@
     ]
   },
   {
+    "provider_name": "Abraia",
+    "provider_url": "https://abraia.me",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://store.abraia.me/*"
+        ],
+        "url": "https://api.abraia.me/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "ActBlue",
+    "provider_url": "https://secure.actblue.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://secure.actblue.com/donate/*"
+        ],
+        "url": "https://secure.actblue.com/cf/oembed"
+      }
+    ]
+  },
+  {
     "provider_name": "Adways",
     "provider_url": "http://www.adways.com",
     "endpoints": [
@@ -45,9 +70,10 @@
     "endpoints": [
       {
         "schemes": [
-          "https://app.altrulabs.com/*/*?answer_id=*"
+          "https://app.altrulabs.com/*/*?answer_id=*",
+          "https://app.altrulabs.com/player/*"
         ],
-        "url": "https://api.altrulabs.com/social/oembed",
+        "url": "https://api.altrulabs.com/api/v1/social/oembed",
         "formats": [
           "json"
         ]
@@ -107,6 +133,19 @@
     ]
   },
   {
+    "provider_name": "ArcGIS StoryMaps",
+    "provider_url": "https://storymaps.arcgis.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://storymaps.arcgis.com/stories/*"
+        ],
+        "url": "https://storymaps.arcgis.com/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Archivos",
     "provider_url": "https://app.archivos.digital",
     "endpoints": [
@@ -115,6 +154,24 @@
           "https://app.archivos.digital/app/view/*"
         ],
         "url": "https://app.archivos.digital/oembed/"
+      }
+    ]
+  },
+  {
+    "provider_name": "Audioboom",
+    "provider_url": "https://audioboom.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://audioboom.com/channels/*",
+          "https://audioboom.com/channel/*",
+          "https://audioboom.com/posts/*"
+        ],
+        "url": "https://audioboom.com/publishing/oembed/v4.{format}",
+        "formats": [
+          "json",
+          "xml"
+        ]
       }
     ]
   },
@@ -134,28 +191,43 @@
   },
   {
     "provider_name": "Audiomack",
-    "provider_url": "https://www.audiomack.com",
+    "provider_url": "https://audiomack.com",
     "endpoints": [
       {
         "schemes": [
-          "https://www.audiomack.com/song/*",
-          "https://www.audiomack.com/album/*",
-          "https://www.audiomack.com/playlist/*"
+          "https://audiomack.com/*/song/*",
+          "https://audiomack.com/*/album/*",
+          "https://audiomack.com/*/playlist/*"
         ],
-        "url": "https://www.audiomack.com/oembed",
+        "url": "https://audiomack.com/oembed",
         "discovery": true
       }
     ]
   },
   {
-    "provider_name": "AudioSnaps",
-    "provider_url": "http://audiosnaps.com",
+    "provider_name": "Avocode",
+    "provider_url": "https://www.avocode.com/",
     "endpoints": [
       {
         "schemes": [
-          "http://audiosnaps.com/k/*"
+          "https://app.avocode.com/view/*"
         ],
-        "url": "http://audiosnaps.com/service/oembed",
+        "url": "https://stage-embed.avocode.com/api/oembed",
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "AxiomNinja",
+    "provider_url": "http://axiom.ninja",
+    "endpoints": [
+      {
+        "schemes": [
+          "http://axiom.ninja/*"
+        ],
+        "url": "http://axiom.ninja/oembed/",
         "discovery": true
       }
     ]
@@ -167,10 +239,10 @@
       {
         "schemes": [
           "https://backtracks.fm/*/*/e/*",
-          "https://backtracks.fm/*",
-          "http://backtracks.fm/*",
           "https://backtracks.fm/*/s/*/*",
-          "https://backtracks.fm/*/*/*/*/e/*/*"
+          "https://backtracks.fm/*/*/*/*/e/*/*",
+          "https://backtracks.fm/*",
+          "http://backtracks.fm/*"
         ],
         "url": "https://backtracks.fm/oembed",
         "discovery": true
@@ -197,6 +269,20 @@
           "https://blackfire.io/profiles/compare/*/graph"
         ],
         "url": "https://blackfire.io/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Blogcast",
+    "provider_url": "https://blogcast.host/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://blogcast.host/embed/*",
+          "https://blogcast.host/embedly/*"
+        ],
+        "url": "https://blogcast.host/oembed",
         "discovery": true
       }
     ]
@@ -306,6 +392,22 @@
     ]
   },
   {
+    "provider_name": "Chainflix",
+    "provider_url": "https://chainflix.net",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://chainflix.net/video/*",
+          "https://chainflix.net/video/embed/*",
+          "https://*.chainflix.net/video/*",
+          "https://*.chainflix.net/video/embed/*"
+        ],
+        "url": "https://www.chainflix.net/video/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "ChartBlocks",
     "provider_url": "http://www.chartblocks.com/",
     "endpoints": [
@@ -372,6 +474,19 @@
     ]
   },
   {
+    "provider_name": "CoCo Corp",
+    "provider_url": "https://ilovecoco.video",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://app.ilovecoco.video/*/embed"
+        ],
+        "url": "https://app.ilovecoco.video/api/oembed.{format}",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "CodeHS",
     "provider_url": "http://www.codehs.com",
     "endpoints": [
@@ -393,7 +508,7 @@
           "http://codepen.io/*",
           "https://codepen.io/*"
         ],
-        "url": "http://codepen.io/api/oembed"
+        "url": "https://codepen.io/api/oembed"
       }
     ]
   },
@@ -477,6 +592,18 @@
     ]
   },
   {
+    "provider_name": "CustomerDB",
+    "provider_url": "http://customerdb.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://app.customerdb.com/share/*"
+        ],
+        "url": "https://app.customerdb.com/embed"
+      }
+    ]
+  },
+  {
     "provider_name": "Cyrano Systems",
     "provider_url": "http://www.cyranosystems.com/",
     "endpoints": [
@@ -494,21 +621,6 @@
     ]
   },
   {
-    "provider_name": "Daily Mile",
-    "provider_url": "http://www.dailymile.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "http://www.dailymile.com/people/*/entries/*"
-        ],
-        "url": "http://api.dailymile.com/oembed?format=json",
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
     "provider_name": "Dailymotion",
     "provider_url": "https://www.dailymotion.com",
     "endpoints": [
@@ -522,14 +634,27 @@
     ]
   },
   {
-    "provider_name": "Deseretnews.com",
-    "provider_url": "https://www.deseretnews.com",
+    "provider_name": "Datawrapper",
+    "provider_url": "http://www.datawrapper.de",
     "endpoints": [
       {
         "schemes": [
-          "https://*.deseretnews.com/*"
+          "https://datawrapper.dwcdn.net/*"
         ],
-        "url": "https://embed.deseretnews.com/"
+        "url": "https://api.datawrapper.de/v3/oembed/",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Deseret News",
+    "provider_url": "https://www.deseret.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.deseret.com/*"
+        ],
+        "url": "https://embed.deseret.com/"
       }
     ]
   },
@@ -539,13 +664,16 @@
     "endpoints": [
       {
         "schemes": [
+          "http://*.deviantart.com/art/*",
+          "http://*.deviantart.com/*#/d*",
+          "http://fav.me/*",
+          "http://sta.sh/*",
           "https://*.deviantart.com/art/*",
           "https://*.deviantart.com/*/art/*",
-          "http://fav.me/*",
-          "https://sta.sh/*",
-          "https://*.deviantart.com/*#/d*"
+          "https://sta.sh/*\",",
+          "https://*.deviantart.com/*#/d*\""
         ],
-        "url": "https://backend.deviantart.com/oembed"
+        "url": "http://backend.deviantart.com/oembed"
       }
     ]
   },
@@ -690,6 +818,19 @@
     ]
   },
   {
+    "provider_name": "Embedery",
+    "provider_url": "https://embedery.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://embedery.com/widget/*"
+        ],
+        "url": "https://embedery.com/api/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Embedly",
     "provider_url": "http://api.embed.ly/",
     "endpoints": [
@@ -726,38 +867,38 @@
     ]
   },
   {
-    "provider_name": "Facebook (Post)",
+    "provider_name": "Facebook",
     "provider_url": "https://www.facebook.com/",
     "endpoints": [
       {
         "schemes": [
           "https://www.facebook.com/*/posts/*",
-          "https://www.facebook.com/photos/*",
-          "https://www.facebook.com/*/photos/*",
-          "https://www.facebook.com/photo.php*",
-          "https://www.facebook.com/photo.php",
           "https://www.facebook.com/*/activity/*",
-          "https://www.facebook.com/permalink.php",
+          "https://www.facebook.com/photo.php?fbid=*",
+          "https://www.facebook.com/photos/*",
+          "https://www.facebook.com/permalink.php?story_fbid=*",
           "https://www.facebook.com/media/set?set=*",
           "https://www.facebook.com/questions/*",
           "https://www.facebook.com/notes/*/*/*"
         ],
-        "url": "https://www.facebook.com/plugins/post/oembed.json",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Facebook (Video)",
-    "provider_url": "https://www.facebook.com/",
-    "endpoints": [
+        "url": "https://graph.facebook.com/v8.0/oembed_post",
+        "discovery": false
+      },
       {
         "schemes": [
           "https://www.facebook.com/*/videos/*",
-          "https://www.facebook.com/video.php"
+          "https://www.facebook.com/video.php?id=*",
+          "https://www.facebook.com/video.php?v=*"
         ],
-        "url": "https://www.facebook.com/plugins/video/oembed.json",
-        "discovery": true
+        "url": "https://graph.facebook.com/v8.0/oembed_video",
+        "discovery": false
+      },
+      {
+        "schemes": [
+          "https://www.facebook.com/*"
+        ],
+        "url": "https://graph.facebook.com/v8.0/oembed_page",
+        "discovery": false
       }
     ]
   },
@@ -789,6 +930,20 @@
           "https://faithlifetv.com/media/resource/*/*"
         ],
         "url": "https://faithlifetv.com/api/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Firework",
+    "provider_url": "https://fireworktv.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.fireworktv.com/*",
+          "https://*.fireworktv.com/embed/*/v/*"
+        ],
+        "url": "https://www.fireworktv.com/oembed",
         "discovery": true
       }
     ]
@@ -847,18 +1002,6 @@
         ],
         "url": "https://app.flourish.studio/api/v1/oembed",
         "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Fontself",
-    "provider_url": "https://www.fontself.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://catapult.fontself.com/*"
-        ],
-        "url": "https://oembed.fontself.com/"
       }
     ]
   },
@@ -1049,10 +1192,56 @@
     "endpoints": [
       {
         "schemes": [
-          "https://hearthis.at/*/*/"
+          "https://hearthis.at/*/*/",
+          "https://hearthis.at/*/set/*/"
         ],
-        "url": "https://hearthis.at/oembed/",
+        "url": "https://hearthis.at/oembed/?format=json",
         "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "hihaho",
+    "provider_url": "https://www.hihaho.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://player.hihaho.com/*"
+        ],
+        "url": "https://player.hihaho.com/services/oembed/*",
+        "formats": [
+          "json",
+          "xml"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Homey",
+    "provider_url": "https://homey.app",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://homey.app/f/*",
+          "https://homey.app/*/flow/*"
+        ],
+        "url": "https://homey.app/api/oembed/flow",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Hosted by You",
+    "provider_url": "https://hostedbyyou.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://hostedbyyou.com/event/*"
+        ],
+        "url": "https://hostedbyyou.com/api/oembed",
+        "formats": [
+          "json"
+        ]
       }
     ]
   },
@@ -1106,6 +1295,19 @@
     ]
   },
   {
+    "provider_name": "iHeartRadio",
+    "provider_url": "https://www.iheart.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.iheart.com/podcast/*/*"
+        ],
+        "url": "https://www.iheart.com/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Indaco",
     "provider_url": "https://player.indacolive.com/",
     "endpoints": [
@@ -1122,13 +1324,13 @@
   },
   {
     "provider_name": "Infogram",
-    "provider_url": "https://infogr.am/",
+    "provider_url": "https://infogram.com/",
     "endpoints": [
       {
         "schemes": [
-          "https://infogr.am/*"
+          "https://infogram.com/*"
         ],
-        "url": "https://infogr.am/oembed"
+        "url": "https://infogram.com/oembed"
       }
     ]
   },
@@ -1193,6 +1395,10 @@
     "endpoints": [
       {
         "schemes": [
+          "http://instagram.com/*/p/*,",
+          "http://www.instagram.com/*/p/*,",
+          "https://instagram.com/*/p/*,",
+          "https://www.instagram.com/*/p/*,",
           "http://instagram.com/p/*",
           "http://instagr.am/p/*",
           "http://www.instagram.com/p/*",
@@ -1200,20 +1406,7 @@
           "https://instagram.com/p/*",
           "https://instagr.am/p/*",
           "https://www.instagram.com/p/*",
-          "https://www.instagr.am/*/p/*",
-          "http://instagram.com/*/p/*",
-          "http://instagr.am/*/p/*",
-          "http://www.instagram.com/*/p/*",
-          "http://www.instagr.am/*/p/*",
-          "https://instagram.com/*/p/*",
-          "https://instagr.am/*/p/*",
-          "https://www.instagram.com/*/p/*",
-          "https://www.instagr.am/*/p/*",
           "https://www.instagr.am/p/*",
-          "http://instagram.com/*/p/*,",
-          "http://www.instagram.com/*/p/*,",
-          "https://instagram.com/*/p/*,",
-          "https://www.instagram.com/*/p/*,",
           "http://instagram.com/tv/*",
           "http://instagr.am/tv/*",
           "http://www.instagram.com/tv/*",
@@ -1227,18 +1420,34 @@
         "formats": [
           "json"
         ]
-      }
-    ]
-  },
-  {
-    "provider_name": "iSnare Articles",
-    "provider_url": "https://www.isnare.com/",
-    "endpoints": [
+      },
       {
         "schemes": [
-          "https://www.isnare.com/*"
+          "http://instagram.com/*/p/*,",
+          "http://www.instagram.com/*/p/*,",
+          "https://instagram.com/*/p/*,",
+          "https://www.instagram.com/*/p/*,",
+          "http://instagram.com/p/*",
+          "http://instagr.am/p/*",
+          "http://www.instagram.com/p/*",
+          "http://www.instagr.am/p/*",
+          "https://instagram.com/p/*",
+          "https://instagr.am/p/*",
+          "https://www.instagram.com/p/*",
+          "https://www.instagr.am/p/*",
+          "http://instagram.com/tv/*",
+          "http://instagr.am/tv/*",
+          "http://www.instagram.com/tv/*",
+          "http://www.instagr.am/tv/*",
+          "https://instagram.com/tv/*",
+          "https://instagr.am/tv/*",
+          "https://www.instagram.com/tv/*",
+          "https://www.instagr.am/tv/*"
         ],
-        "url": "https://www.isnare.com/oembed/"
+        "url": "https://graph.facebook.com/v8.0/instagram_oembed",
+        "formats": [
+          "json"
+        ]
       }
     ]
   },
@@ -1261,6 +1470,24 @@
     "endpoints": [
       {
         "url": "https://music.ivlis.kr/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Jovian",
+    "provider_url": "https://jovian.ai/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://jovian.ml/*",
+          "https://jovian.ml/viewer*",
+          "https://*.jovian.ml/*",
+          "https://jovian.ai/*",
+          "https://jovian.ai/viewer*",
+          "https://*.jovian.ai/*"
+        ],
+        "url": "https://api.jovian.ai/oembed.json",
         "discovery": true
       }
     ]
@@ -1307,28 +1534,29 @@
     ]
   },
   {
-    "provider_name": "Kijk",
-    "provider_url": "https://www.kijk.nl/",
+    "provider_name": "Kirim.Email",
+    "provider_url": "https://kirim.email/",
     "endpoints": [
       {
         "schemes": [
-          "https://www.kijk.nl/video/*",
-          "https://www.kijk.nl/*/*/videos/*/*"
+          "https://halaman.email/form/*",
+          "https://aplikasi.kirim.email/form/*"
         ],
-        "url": "https://oembed.kijk.nl"
+        "url": "https://halaman.email/service/oembed",
+        "discovery": true
       }
     ]
   },
   {
     "provider_name": "Kit",
-    "provider_url": "https://kit.com/",
+    "provider_url": "https://kit.co/",
     "endpoints": [
       {
         "schemes": [
-          "http://kit.com/*/*",
-          "https://kit.com/*/*"
+          "http://kit.co/*/*",
+          "https://kit.co/*/*"
         ],
-        "url": "https://embed.kit.com/oembed",
+        "url": "https://embed.kit.co/oembed",
         "discovery": true
       }
     ]
@@ -1347,6 +1575,19 @@
     ]
   },
   {
+    "provider_name": "kmdr",
+    "provider_url": "https://kmdr.sh",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://app.kmdr.sh/h/*",
+          "https://app.kmdr.sh/history/*"
+        ],
+        "url": "https://api.kmdr.sh/services/oembed"
+      }
+    ]
+  },
+  {
     "provider_name": "Knacki",
     "provider_url": "http://jdr.knacki.info",
     "endpoints": [
@@ -1360,6 +1601,21 @@
     ]
   },
   {
+    "provider_name": "Knowledge Pad",
+    "provider_url": "https://knowledgepad.co/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://knowledgepad.co/#/knowledge/*"
+        ],
+        "url": "https://api.spoonacular.com/knowledge/oembed",
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
     "provider_name": "LearningApps.org",
     "provider_url": "http://learningapps.org/",
     "endpoints": [
@@ -1368,6 +1624,19 @@
           "http://learningapps.org/*"
         ],
         "url": "http://learningapps.org/oembed.php",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "LeMans.Pod",
+    "provider_url": "https://umotion-test.univ-lemans.fr/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://umotion-test.univ-lemans.fr/video/*"
+        ],
+        "url": "https://umotion-test.univ-lemans.fr/oembed",
         "discovery": true
       }
     ]
@@ -1420,6 +1689,19 @@
     ]
   },
   {
+    "provider_name": "Lumiere",
+    "provider_url": "https://latd.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.lumiere.is/v/*"
+        ],
+        "url": "https://admin.lumiere.is/api/services/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "MathEmbed",
     "provider_url": "http://mathembed.com",
     "endpoints": [
@@ -1459,6 +1741,24 @@
     ]
   },
   {
+    "provider_name": "MediaLab",
+    "provider_url": "https://www.medialab.co/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.medialab.app/share/watch/*",
+          "https://*.medialab.co/share/watch/*",
+          "https://*.medialab.app/share/social/*",
+          "https://*.medialab.co/share/social/*",
+          "https://*.medialab.app/share/embed/*",
+          "https://*.medialab.co/share/embed/*"
+        ],
+        "url": "https://*.medialab.(co|app)/api/oembed/",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Medienarchiv der Künste - Zürcher Hochschule der Künste",
     "provider_url": "https://medienarchiv.zhdk.ch/",
     "endpoints": [
@@ -1486,6 +1786,43 @@
         "formats": [
           "json"
         ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Mermaid Ink",
+    "provider_url": "https://mermaid.ink",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://mermaid.ink/img/*",
+          "https://mermaid.ink/svg/*"
+        ],
+        "url": "https://mermaid.ink/services/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Microlink",
+    "provider_url": "http://api.microlink.io",
+    "endpoints": [
+      {
+        "url": "https://api.microlink.io"
+      }
+    ]
+  },
+  {
+    "provider_name": "Microsoft Stream",
+    "provider_url": "https://stream.microsoft.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.microsoftstream.com/video/*",
+          "https://*.microsoftstream.com/channel/*"
+        ],
+        "url": "https://web.microsoftstream.com/oembed",
+        "discovery": true
       }
     ]
   },
@@ -1573,6 +1910,23 @@
     ]
   },
   {
+    "provider_name": "Namchey",
+    "provider_url": "https://namchey.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://namchey.com/embeds/*"
+        ],
+        "url": "https://namchey.com/api/oembed",
+        "formats": [
+          "json",
+          "xml"
+        ],
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "nanoo.tv",
     "provider_url": "https://www.nanoo.tv/",
     "endpoints": [
@@ -1610,6 +1964,25 @@
     ]
   },
   {
+    "provider_name": "Natural Atlas",
+    "provider_url": "https://naturalatlas.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://naturalatlas.com/*",
+          "https://naturalatlas.com/*/*",
+          "https://naturalatlas.com/*/*/*",
+          "https://naturalatlas.com/*/*/*/*"
+        ],
+        "url": "https://naturalatlas.com/oembed.{format}",
+        "discovery": true,
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
     "provider_name": "nfb.ca",
     "provider_url": "http://www.nfb.ca/",
     "endpoints": [
@@ -1623,6 +1996,36 @@
     ]
   },
   {
+    "provider_name": "NoPaste",
+    "provider_url": "https://nopaste.ml",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://nopaste.ml/*"
+        ],
+        "url": "https://oembed.nopaste.ml",
+        "discovery": false
+      }
+    ]
+  },
+  {
+    "provider_name": "Observable",
+    "provider_url": "https://observablehq.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://observablehq.com/@*/*",
+          "https://observablehq.com/d/*",
+          "https://observablehq.com/embed/*"
+        ],
+        "url": "https://api.observablehq.com/oembed",
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
     "provider_name": "Odds.com.au",
     "provider_url": "https://www.odds.com.au",
     "endpoints": [
@@ -1632,6 +2035,28 @@
           "https://odds.com.au/*"
         ],
         "url": "https://www.odds.com.au/api/oembed/"
+      }
+    ]
+  },
+  {
+    "provider_name": "Odesli (formerly Songlink)",
+    "provider_url": "https://odesli.co",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://song.link/*",
+          "https://album.link/*",
+          "https://artist.link/*",
+          "https://playlist.link/*",
+          "https://pods.link/*",
+          "https://mylink.page/*",
+          "https://odesli.co/*"
+        ],
+        "url": "https://song.link/oembed",
+        "formats": [
+          "json"
+        ],
+        "discovery": true
       }
     ]
   },
@@ -1748,6 +2173,35 @@
     ]
   },
   {
+    "provider_name": "OZ",
+    "provider_url": "https://www.oz.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.oz.com/*/video/*"
+        ],
+        "url": "https://core.oz.com/oembed",
+        "formats": [
+          "json",
+          "xml"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Padlet",
+    "provider_url": "https://padlet.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://padlet.com/*"
+        ],
+        "url": "https://padlet.com/oembed/",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Pastery",
     "provider_url": "https://www.pastery.net",
     "endpoints": [
@@ -1770,6 +2224,23 @@
       {
         "url": "https://beta.pingvp.com.kpnis.nl/p/oembed.php",
         "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Pinpoll",
+    "provider_url": "https://www.pinpoll.com/products/tools",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://tools.pinpoll.com/embed/*"
+        ],
+        "url": "https://tools.pinpoll.com/oembed",
+        "discovery": true,
+        "formats": [
+          "json",
+          "xml"
+        ]
       }
     ]
   },
@@ -1801,6 +2272,19 @@
           "http://*.podbean.com/e/*"
         ],
         "url": "https://api.podbean.com/v1/oembed"
+      }
+    ]
+  },
+  {
+    "provider_name": "Polaris Share",
+    "provider_url": "https://www.polarishare.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.polarishare.com/*/*"
+        ],
+        "url": "https://api.polarishare.com/rest/api/oembed",
+        "discovery": true
       }
     ]
   },
@@ -1843,6 +2327,29 @@
     ]
   },
   {
+    "provider_name": "posiXion",
+    "provider_url": "https://posixion.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://posixion.com/question/*",
+          "https://posixion.com/*/question/*"
+        ],
+        "url": "http://posixion.com/services/oembed/"
+      }
+    ]
+  },
+  {
+    "provider_name": "Qualifio",
+    "provider_url": "https://qualifio.com/",
+    "endpoints": [
+      {
+        "url": "https://oembed.qualifio.com/",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Quiz.biz",
     "provider_url": "http://www.quiz.biz/",
     "endpoints": [
@@ -1869,14 +2376,37 @@
     ]
   },
   {
-    "provider_name": "RapidEngage",
-    "provider_url": "https://rapidengage.com",
+    "provider_name": "RadioPublic",
+    "provider_url": "https://radiopublic.com",
     "endpoints": [
       {
         "schemes": [
-          "https://rapidengage.com/s/*"
+          "https://play.radiopublic.com/*",
+          "https://radiopublic.com/*",
+          "https://www.radiopublic.com/*",
+          "http://play.radiopublic.com/*",
+          "http://radiopublic.com/*",
+          "http://www.radiopublic.com/*",
+          "https://*.radiopublic.com/*'"
         ],
-        "url": "https://rapidengage.com/api/oembed"
+        "url": "https://oembed.radiopublic.com/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "rcvis",
+    "provider_url": "https://www.rcvis.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.rcvis.com/v/*",
+          "https://www.rcvis.com/visualize=*",
+          "https://www.rcvis.com/ve/*",
+          "https://www.rcvis.com/visualizeEmbedded=*"
+        ],
+        "url": "https://animatron.com/oembed",
+        "discovery": true
       }
     ]
   },
@@ -1992,6 +2522,34 @@
       {
         "url": "https://rumble.com/api/Media/oembed.{format}",
         "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Runkit",
+    "provider_url": "https://runkit.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "http://embed.runkit.com/*,",
+          "https://embed.runkit.com/*,"
+        ],
+        "url": "https://embed.runkit.com/oembed",
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Saooti",
+    "provider_url": "https://octopus.saooti.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://octopus.saooti.com/main/pub/podcast/*"
+        ],
+        "url": "https://octopus.saooti.com/oembed"
       }
     ]
   },
@@ -2114,6 +2672,20 @@
     ]
   },
   {
+    "provider_name": "Show by Animaker",
+    "provider_url": "https://getshow.io/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://app.getshow.io/iframe/*",
+          "https://*.getshow.io/share/*"
+        ],
+        "url": "https://api.getshow.io/oembed.{format}",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Show the Way, actionable location info",
     "provider_url": "https://showtheway.io",
     "endpoints": [
@@ -2177,26 +2749,46 @@
     "endpoints": [
       {
         "schemes": [
+          "https://www.slideshare.net/*/*",
           "http://www.slideshare.net/*/*",
+          "https://fr.slideshare.net/*/*",
           "http://fr.slideshare.net/*/*",
+          "https://de.slideshare.net/*/*",
           "http://de.slideshare.net/*/*",
+          "https://es.slideshare.net/*/*",
           "http://es.slideshare.net/*/*",
+          "https://pt.slideshare.net/*/*",
           "http://pt.slideshare.net/*/*"
         ],
-        "url": "http://www.slideshare.net/api/oembed/2",
+        "url": "https://www.slideshare.net/api/oembed/2",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "SmashNotes",
+    "provider_url": "https://smashnotes.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://smashnotes.com/p/*",
+          "https://smashnotes.com/p/*/e/* - https://smashnotes.com/p/*/e/*/s/*"
+        ],
+        "url": "https://smashnotes.com/services/oembed",
         "discovery": true
       }
     ]
   },
   {
     "provider_name": "SmugMug",
-    "provider_url": "http://www.smugmug.com/",
+    "provider_url": "https://www.smugmug.com/",
     "endpoints": [
       {
         "schemes": [
-          "http://*.smugmug.com/*"
+          "http://*.smugmug.com/*",
+          "https://*.smugmug.com/*"
         ],
-        "url": "http://api.smugmug.com/services/oembed/",
+        "url": "https://api.smugmug.com/services/oembed/",
         "discovery": true
       }
     ]
@@ -2218,22 +2810,6 @@
     ]
   },
   {
-    "provider_name": "Songlink",
-    "provider_url": "https://song.link",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://song.link/*"
-        ],
-        "url": "https://song.link/oembed",
-        "formats": [
-          "json"
-        ],
-        "discovery": true
-      }
-    ]
-  },
-  {
     "provider_name": "SoundCloud",
     "provider_url": "http://soundcloud.com/",
     "endpoints": [
@@ -2244,24 +2820,6 @@
           "https://soundcloud.app.goog.gl/*"
         ],
         "url": "https://soundcloud.com/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "Soundsgood",
-    "provider_url": "https://soundsgood.co",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://play.soundsgood.co/playlist/*",
-          "https://soundsgood.co/playlist/*"
-        ],
-        "url": "https://play.soundsgood.co/oembed",
-        "discovery": true,
-        "formats": [
-          "json",
-          "xml"
-        ]
       }
     ]
   },
@@ -2363,6 +2921,35 @@
     ]
   },
   {
+    "provider_name": "Subscribi",
+    "provider_url": "https://subscribi.io/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://subscribi.io/api/oembed*"
+        ],
+        "url": "https://subscribi.io/api/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Sudomemo",
+    "provider_url": "https://www.sudomemo.net/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.sudomemo.net/watch/*",
+          "http://www.sudomemo.net/watch/*",
+          "https://flipnot.es/*",
+          "http://flipnot.es/*"
+        ],
+        "url": "https://www.sudomemo.net/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Sutori",
     "provider_url": "https://www.sutori.com/",
     "endpoints": [
@@ -2393,8 +2980,8 @@
     ]
   },
   {
-    "provider_name": "Ted",
-    "provider_url": "https://ted.com",
+    "provider_name": "TED",
+    "provider_url": "https://www.ted.com",
     "endpoints": [
       {
         "schemes": [
@@ -2402,7 +2989,8 @@
           "https://ted.com/talks/*",
           "https://www.ted.com/talks/*"
         ],
-        "url": "https://www.ted.com/talks/oembed.{format}"
+        "url": "https://www.ted.com/services/v1/oembed.{format}",
+        "discovery": true
       }
     ]
   },
@@ -2455,6 +3043,18 @@
     ]
   },
   {
+    "provider_name": "TikTok",
+    "provider_url": "http://www.tiktok.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.tiktok.com/*/video/*"
+        ],
+        "url": "https://www.tiktok.com/oembed"
+      }
+    ]
+  },
+  {
     "provider_name": "Toornament",
     "provider_url": "https://www.toornament.com/",
     "endpoints": [
@@ -2488,6 +3088,34 @@
     ]
   },
   {
+    "provider_name": "TourHero",
+    "provider_url": "http://www.tourhero.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.tourhero.com/*"
+        ],
+        "url": "https://oembed.tourhero.com/",
+        "discovery": true,
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Tumblr",
+    "provider_url": "https://www.tumblr.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.tumblr.com/post/*"
+        ],
+        "url": "https://www.tumblr.com/oembed/1.0"
+      }
+    ]
+  },
+  {
     "provider_name": "Tuxx",
     "provider_url": "https://www.tuxx.be/",
     "endpoints": [
@@ -2506,9 +3134,10 @@
     "endpoints": [
       {
         "schemes": [
-          "http://www.tvcf.co.kr/v/*"
+          "https://play.tvcf.co.kr/*",
+          "https://*.tvcf.co.kr/*"
         ],
-        "url": "http://www.tvcf.co.kr/services/oembed"
+        "url": "https://play.tvcf.co.kr/rest/oembed"
       }
     ]
   },
@@ -2524,6 +3153,30 @@
           "https://*.twitter.com/*/moments/*"
         ],
         "url": "https://publish.twitter.com/oembed"
+      }
+    ]
+  },
+  {
+    "provider_name": "TypeCast",
+    "provider_url": "https://typecast.ai",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://play.typecast.ai/s/*",
+          "https://play.typecast.ai/e/*",
+          "https://play.typecast.ai/*"
+        ],
+        "url": "https://play.typecast.ai/oembed"
+      }
+    ]
+  },
+  {
+    "provider_name": "Typlog",
+    "provider_url": "https://typlog.com",
+    "endpoints": [
+      {
+        "url": "https://typlog.com/oembed",
+        "discovery": true
       }
     ]
   },
@@ -2555,6 +3208,19 @@
     ]
   },
   {
+    "provider_name": "UnivParis1.Pod",
+    "provider_url": "https://mediatheque.univ-paris1.fr/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://mediatheque.univ-paris1.fr/video/*"
+        ],
+        "url": "https://mediatheque.univ-paris1.fr/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "UOL",
     "provider_url": "https://mais.uol.com.br/",
     "endpoints": [
@@ -2569,6 +3235,19 @@
     ]
   },
   {
+    "provider_name": "uppy",
+    "provider_url": "https://uppy.jp",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://app.uppy.jp/_shares/video/*"
+        ],
+        "url": "https://api.uppy.jp/v1/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Ustream",
     "provider_url": "http://www.ustream.tv",
     "endpoints": [
@@ -2578,6 +3257,23 @@
           "http://*.ustream.com/*"
         ],
         "url": "http://www.ustream.tv/oembed",
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "uStudio, Inc.",
+    "provider_url": "https://www.ustudio.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.ustudio.com/embed/*",
+          "https://*.ustudio.com/embed/*/*"
+        ],
+        "url": "https://app.ustudio.com/api/v2/oembed",
+        "discovery": true,
         "formats": [
           "json"
         ]
@@ -2690,7 +3386,6 @@
     "endpoints": [
       {
         "schemes": [
-          "https://players.vidmizer.com/*",
           "https://players-cdn-v2.vidmizer.com/*"
         ],
         "url": "https://app-v2.vidmizer.com/api/oembed",
@@ -2700,16 +3395,13 @@
   },
   {
     "provider_name": "Vidyard",
-    "provider_url": "http://www.vidyard.com",
+    "provider_url": "https://vidyard.com",
     "endpoints": [
       {
         "schemes": [
-          "http://embed.vidyard.com/*",
-          "http://play.vidyard.com/*",
-          "http://share.vidyard.com/*",
-          "http://*.hubs.vidyard.com/*",
           "http://*.vidyard.com/*",
           "https://*.vidyard.com/*",
+          "http://*.hubs.vidyard.com/*",
           "https://*.hubs.vidyard.com/*"
         ],
         "url": "https://api.vidyard.com/dashboard/v1.1/oembed",
@@ -2736,6 +3428,23 @@
     ]
   },
   {
+    "provider_name": "Viously",
+    "provider_url": "https://www.viously.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://www.viously.com/*/*"
+        ],
+        "url": "https://www.viously.com/oembed",
+        "discovery": true,
+        "formats": [
+          "json",
+          "xml"
+        ]
+      }
+    ]
+  },
+  {
     "provider_name": "Viziosphere",
     "provider_url": "http://www.viziosphere.com",
     "endpoints": [
@@ -2745,6 +3454,18 @@
         ],
         "url": "http://viziosphere.com/services/oembed/",
         "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Vizydrop",
+    "provider_url": "https://vizydrop.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://vizydrop.com/shared/*"
+        ],
+        "url": "https://vizydrop.com/oembed"
       }
     ]
   },
@@ -2807,6 +3528,20 @@
     ]
   },
   {
+    "provider_name": "Wave.video",
+    "provider_url": "https://wave.video",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://watch.wave.video/*",
+          "https://embed.wave.video/*"
+        ],
+        "url": "https://embed.wave.video/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "wecandeo",
     "provider_url": "http://www.wecandeo.com/",
     "endpoints": [
@@ -2864,6 +3599,35 @@
     ]
   },
   {
+    "provider_name": "Wokwi",
+    "provider_url": "https://wokwi.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://wokwi.com/share/*"
+        ],
+        "url": "https://wokwi.com/api/oembed",
+        "discovery": true,
+        "formats": [
+          "json"
+        ]
+      }
+    ]
+  },
+  {
+    "provider_name": "Wolfram Cloud",
+    "provider_url": "https://www.wolframcloud.com",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://*.wolframcloud.com/*"
+        ],
+        "url": "https://www.wolframcloud.com/oembed",
+        "discovery": true
+      }
+    ]
+  },
+  {
     "provider_name": "Wootled",
     "provider_url": "http://www.wootled.com/",
     "endpoints": [
@@ -2879,6 +3643,22 @@
       {
         "url": "http://public-api.wordpress.com/oembed/",
         "discovery": true
+      }
+    ]
+  },
+  {
+    "provider_name": "Xpression",
+    "provider_url": "https://web.xpression.jp",
+    "endpoints": [
+      {
+        "schemes": [
+          "https://web.xpression.jp/video/*"
+        ],
+        "url": "https://web.xpression.jp/api/oembed",
+        "formats": [
+          "json",
+          "xml"
+        ]
       }
     ]
   },
@@ -2922,767 +3702,11 @@
       {
         "schemes": [
           "https://*.youtube.com/watch*",
-          "https://*.youtube.com/v/*\"",
-          "https://youtu.be/*",
-          "https://*.youtube.com/v/*"
+          "https://*.youtube.com/v/*",
+          "https://youtu.be/*"
         ],
         "url": "https://www.youtube.com/oembed",
         "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "ZnipeTV",
-    "provider_url": "https://www.znipe.tv/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.znipe.tv/*"
-        ],
-        "url": "https://api.znipe.tv/v3/oembed/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "ZProvider",
-    "provider_url": "https://reports.zoho.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://reports.zoho.com/ZDBDataSheetView.cc?OBJID=1432535000000003002&STANDALONE=true&INTERVAL=120&DATATYPESYMBOL=false&REMTOOLBAR=false&SEARCHBOX=true&INCLUDETITLE=true&INCLUDEDESC=true&SHOWHIDEOPT=true"
-        ],
-        "url": "http://api.provider.com/oembed.json",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Namchey",
-    "provider_url": "https://namchey.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://namchey.com/embeds/*"
-        ],
-        "url": "https://namchey.com/api/oembed",
-        "formats": [
-          "json",
-          "xml"
-        ],
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Natural Atlas",
-    "provider_url": "https://naturalatlas.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://naturalatlas.com/*",
-          "https://naturalatlas.com/*/*",
-          "https://naturalatlas.com/*/*/*",
-          "https://naturalatlas.com/*/*/*/*"
-        ],
-        "url": "https://naturalatlas.com/oembed.{format}",
-        "discovery": true,
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "posiXion",
-    "provider_url": "https://posixion.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://posixion.com/question/*",
-          "https://posixion.com/*/question/*"
-        ],
-        "url": "http://posixion.com/services/oembed/"
-      }
-    ]
-  },
-  {
-    "provider_name": "SmashNotes",
-    "provider_url": "https://smashnotes.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://smashnotes.com/p/*",
-          "https://smashnotes.com/p/*/e/* - https://smashnotes.com/p/*/e/*/s/*"
-        ],
-        "url": "https://smashnotes.com/services/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "TypeCast",
-    "provider_url": "https://typecast.ai",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://play.typecast.ai/s/*",
-          "https://play.typecast.ai/e/*",
-          "https://play.typecast.ai/*"
-        ],
-        "url": "https://play.typecast.ai/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "Audioboom",
-    "provider_url": "https://audioboom.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://audioboom.com/channel/*",
-          "https://audioboom.com/posts/*",
-          "https://audioboom.com/channels/*"
-        ],
-        "url": "https://audioboom.com/publishing/oembed/v4.{format}",
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Blogcast",
-    "provider_url": "https://blogcast.host/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://blogcast.host/embed/*",
-          "https://blogcast.host/embedly/*"
-        ],
-        "url": "https://blogcast.host/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Facebook",
-    "provider_url": "https://www.facebook.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.facebook.com/*/posts/*",
-          "https://www.facebook.com/photos/*",
-          "https://www.facebook.com/*/photos/*",
-          "https://www.facebook.com/photo.php*",
-          "https://www.facebook.com/photo.php",
-          "https://www.facebook.com/*/activity/*",
-          "https://www.facebook.com/permalink.php",
-          "https://www.facebook.com/media/set?set=*",
-          "https://www.facebook.com/questions/*",
-          "https://www.facebook.com/notes/*/*/*"
-        ],
-        "url": "https://www.facebook.com/plugins/post/oembed.json",
-        "discovery": true
-      },
-      {
-        "schemes": [
-          "https://www.facebook.com/*/videos/*",
-          "https://www.facebook.com/video.php"
-        ],
-        "url": "https://www.facebook.com/plugins/video/oembed.json",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "OZ",
-    "provider_url": "https://www.oz.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.oz.com/*/video/*"
-        ],
-        "url": "https://core.oz.com/oembed",
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Polaris Share",
-    "provider_url": "https://www.polarishare.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.polarishare.com/*/*"
-        ],
-        "url": "https://api.polarishare.com/rest/api/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Typlog",
-    "provider_url": "https://typlog.com",
-    "endpoints": [
-      {
-        "url": "https://typlog.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "uStudio, Inc.",
-    "provider_url": "https://www.ustudio.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.ustudio.com/embed/*",
-          "https://*.ustudio.com/embed/*/*"
-        ],
-        "url": "https://app.ustudio.com/api/v2/oembed",
-        "discovery": true,
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Abraia",
-    "provider_url": "https://abraia.me",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://store.abraia.me/*"
-        ],
-        "url": "https://api.abraia.me/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "ArcGIS StoryMaps",
-    "provider_url": "https://storymaps.arcgis.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://storymaps.arcgis.com/stories/*"
-        ],
-        "url": "https://storymaps.arcgis.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Avocode",
-    "provider_url": "https://www.avocode.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://app.avocode.com/view/*"
-        ],
-        "url": "https://stage-embed.avocode.com/api/oembed",
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Deseret News",
-    "provider_url": "https://www.deseret.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.deseret.com/*"
-        ],
-        "url": "https://embed.deseret.com/"
-      }
-    ]
-  },
-  {
-    "provider_name": "Firework",
-    "provider_url": "https://fireworktv.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.fireworktv.com/*",
-          "https://*.fireworktv.com/embed/*/v/*"
-        ],
-        "url": "https://www.fireworktv.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Homey",
-    "provider_url": "https://homey.app",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://homey.app/f/*",
-          "https://homey.app/*/flow/*"
-        ],
-        "url": "https://homey.app/api/oembed/flow",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "iHeartRadio",
-    "provider_url": "https://www.iheart.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.iheart.com/podcast/*/*"
-        ],
-        "url": "https://www.iheart.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Jovian",
-    "provider_url": "https://jovian.ml/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://jovian.ml/*",
-          "https://jovian.ml/viewer*",
-          "https://*.jovian.ml/*",
-          "https://jovian.ai/*",
-          "https://jovian.ai/viewer*",
-          "https://*.jovian.ai/*"
-        ],
-        "url": "https://api.jovian.ai/oembed.json",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Kirim.Email",
-    "provider_url": "https://kirim.email/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://halaman.email/form/*",
-          "https://aplikasi.kirim.email/form/*"
-        ],
-        "url": "https://halaman.email/service/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "MediaLab",
-    "provider_url": "https://www.medialab.co/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.medialab.app/share/watch/*",
-          "https://*.medialab.co/share/watch/*",
-          "https://*.medialab.app/share/social/*",
-          "https://*.medialab.co/share/social/*",
-          "https://*.medialab.app/share/embed/*",
-          "https://*.medialab.co/share/embed/*"
-        ],
-        "url": "https://*.medialab.(co|app)/api/oembed/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Mermaid Ink",
-    "provider_url": "https://mermaid.ink",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://mermaid.ink/img/*",
-          "https://mermaid.ink/svg/*"
-        ],
-        "url": "https://mermaid.ink/services/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Microlink",
-    "provider_url": "http://api.microlink.io",
-    "endpoints": [
-      {
-        "url": "https://api.microlink.io"
-      }
-    ]
-  },
-  {
-    "provider_name": "TED",
-    "provider_url": "https://www.ted.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "http://ted.com/talks/*",
-          "https://ted.com/talks/*",
-          "https://www.ted.com/talks/*"
-        ],
-        "url": "https://www.ted.com/services/v1/oembed.{format}",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "UnivParis1.Pod",
-    "provider_url": "https://mediatheque.univ-paris1.fr/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://mediatheque.univ-paris1.fr/video/*"
-        ],
-        "url": "https://mediatheque.univ-paris1.fr/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Viously",
-    "provider_url": "https://www.viously.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.viously.com/*/*"
-        ],
-        "url": "https://www.viously.com/oembed",
-        "discovery": true,
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Vizydrop",
-    "provider_url": "https://vizydrop.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://vizydrop.com/shared/*"
-        ],
-        "url": "https://vizydrop.com/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "Xpression",
-    "provider_url": "https://web.xpression.jp",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://web.xpression.jp/video/*"
-        ],
-        "url": "https://web.xpression.jp/api/oembed",
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "ZingSoft",
-    "provider_url": "https://app.zingsoft.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://app.zingsoft.com/embed/*",
-          "https://app.zingsoft.com/view/*"
-        ],
-        "url": "https://app.zingsoft.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Zoomable",
-    "provider_url": "https://zoomable.ca/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://srv2.zoomable.ca/viewer.php*"
-        ],
-        "url": "https://srv2.zoomable.ca/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "AxiomNinja",
-    "provider_url": "http://axiom.ninja",
-    "endpoints": [
-      {
-        "schemes": [
-          "http://axiom.ninja/*"
-        ],
-        "url": "http://axiom.ninja/oembed/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Chainflix",
-    "provider_url": "https://chainflix.net",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://chainflix.net/video/*",
-          "https://chainflix.net/video/embed/*",
-          "https://*.chainflix.net/video/*",
-          "https://*.chainflix.net/video/embed/*"
-        ],
-        "url": "https://beta.chainflix.net/video/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "CoCo Corp",
-    "provider_url": "https://ilovecoco.video",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://app.ilovecoco.video/*/embed"
-        ],
-        "url": "https://app.ilovecoco.video/api/oembed.{format}",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Datawrapper",
-    "provider_url": "http://www.datawrapper.de",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://datawrapper.dwcdn.net/*"
-        ],
-        "url": "https://api.datawrapper.de/v3/oembed/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Embedery",
-    "provider_url": "https://embedery.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://embedery.com/widget/*"
-        ],
-        "url": "https://embedery.com/api/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "hihaho",
-    "provider_url": "https://www.hihaho.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://player.hihaho.com/*"
-        ],
-        "url": "https://player.hihaho.com/services/oembed/*",
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Knowledge Pad",
-    "provider_url": "https://knowledgepad.co/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://knowledgepad.co/#/knowledge/*"
-        ],
-        "url": "https://api.spoonacular.com/knowledge/oembed",
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "LeMans.Pod",
-    "provider_url": "https://umotion-test.univ-lemans.fr/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://umotion-test.univ-lemans.fr/video/*"
-        ],
-        "url": "https://umotion-test.univ-lemans.fr/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Microsoft Stream",
-    "provider_url": "https://stream.microsoft.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.microsoftstream.com/video/*",
-          "https://*.microsoftstream.com/channel/*"
-        ],
-        "url": "https://web.microsoftstream.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Odesli (formerly Songlink)",
-    "provider_url": "https://odesli.co",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://song.link/*",
-          "https://album.link/*",
-          "https://artist.link/*",
-          "https://playlist.link/*",
-          "https://pods.link/*",
-          "https://mylink.page/*",
-          "https://odesli.co/*"
-        ],
-        "url": "https://song.link/oembed",
-        "formats": [
-          "json"
-        ],
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Padlet",
-    "provider_url": "https://padlet.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://padlet.com/*"
-        ],
-        "url": "https://padlet.com/oembed/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Pinpoll",
-    "provider_url": "https://www.pinpoll.com/products/tools",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://tools.pinpoll.com/embed/*"
-        ],
-        "url": "https://tools.pinpoll.com/oembed",
-        "discovery": true,
-        "formats": [
-          "json",
-          "xml"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Qualifio",
-    "provider_url": "https://qualifio.com/",
-    "endpoints": [
-      {
-        "url": "https://oembed.qualifio.com/",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "RadioPublic",
-    "provider_url": "https://radiopublic.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://play.radiopublic.com/*",
-          "https://radiopublic.com/*",
-          "https://www.radiopublic.com/*",
-          "http://play.radiopublic.com/*",
-          "http://radiopublic.com/*",
-          "http://www.radiopublic.com/*",
-          "https://*.radiopublic.com/*'"
-        ],
-        "url": "https://oembed.radiopublic.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Runkit",
-    "provider_url": "https://runkit.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "http://embed.runkit.com/*,",
-          "https://embed.runkit.com/*,"
-        ],
-        "url": "https://embed.runkit.com/oembed",
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "TikTok",
-    "provider_url": "http://www.tiktok.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.tiktok.com/*/video/*",
-          "https://www.tiktok.com/*/video/*",
-          "https://m.tiktok.com/v/*"
-        ],
-        "url": "https://www.tiktok.com/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "Wave.video",
-    "provider_url": "https://wave.video",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://watch.wave.video/*",
-          "https://embed.wave.video/*"
-        ],
-        "url": "https://embed.wave.video/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "Wokwi",
-    "provider_url": "https://wokwi.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://wokwi.com/share/*"
-        ],
-        "url": "https://wokwi.com/api/oembed",
-        "discovery": true,
-        "formats": [
-          "json"
-        ]
       }
     ]
   },
@@ -3703,164 +3727,41 @@
     ]
   },
   {
-    "provider_name": "Lumiere",
-    "provider_url": "https://latd.com",
+    "provider_name": "ZingSoft",
+    "provider_url": "https://app.zingsoft.com",
     "endpoints": [
       {
         "schemes": [
-          "https://*.lumiere.is/v/*"
+          "https://app.zingsoft.com/embed/*",
+          "https://app.zingsoft.com/view/*"
         ],
-        "url": "https://admin.lumiere.is/api/services/oembed",
+        "url": "https://app.zingsoft.com/oembed",
         "discovery": true
       }
     ]
   },
   {
-    "provider_name": "NoPaste",
-    "provider_url": "https://nopaste.ml",
+    "provider_name": "ZnipeTV",
+    "provider_url": "https://www.znipe.tv/",
     "endpoints": [
       {
         "schemes": [
-          "https://nopaste.ml/*"
+          "https://*.znipe.tv/*"
         ],
-        "url": "https://oembed.nopaste.ml",
-        "discovery": false
-      }
-    ]
-  },
-  {
-    "provider_name": "Observable",
-    "provider_url": "https://observablehq.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://observablehq.com/@*/*",
-          "https://observablehq.com/d/*",
-          "https://observablehq.com/embed/*"
-        ],
-        "url": "https://api.observablehq.com/oembed",
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "rcvis",
-    "provider_url": "https://www.rcvis.com/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.rcvis.com/v/*",
-          "https://www.rcvis.com/visualize=*",
-          "https://www.rcvis.com/ve/*",
-          "https://www.rcvis.com/visualizeEmbedded=*"
-        ],
-        "url": "https://animatron.com/oembed",
+        "url": "https://api.znipe.tv/v3/oembed/",
         "discovery": true
       }
     ]
   },
   {
-    "provider_name": "Saooti",
-    "provider_url": "https://octopus.saooti.com",
+    "provider_name": "Zoomable",
+    "provider_url": "https://zoomable.ca/",
     "endpoints": [
       {
         "schemes": [
-          "https://octopus.saooti.com/main/pub/podcast/*"
+          "https://srv2.zoomable.ca/viewer.php*"
         ],
-        "url": "https://octopus.saooti.com/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "Subscribi",
-    "provider_url": "https://subscribi.io/",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://subscribi.io/api/oembed*"
-        ],
-        "url": "https://subscribi.io/api/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "TourHero",
-    "provider_url": "http://www.tourhero.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://www.tourhero.com/*"
-        ],
-        "url": "https://oembed.tourhero.com/",
-        "discovery": true,
-        "formats": [
-          "json"
-        ]
-      }
-    ]
-  },
-  {
-    "provider_name": "Tumblr",
-    "provider_url": "https://www.tumblr.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.tumblr.com/post/*"
-        ],
-        "url": "https://www.tumblr.com/oembed/1.0"
-      }
-    ]
-  },
-  {
-    "provider_name": "Wolfram Cloud",
-    "provider_url": "https://www.wolframcloud.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://*.wolframcloud.com/*"
-        ],
-        "url": "https://www.wolframcloud.com/oembed",
-        "discovery": true
-      }
-    ]
-  },
-  {
-    "provider_name": "ActBlue",
-    "provider_url": "https://secure.actblue.com",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://secure.actblue.com/donate/*"
-        ],
-        "url": "https://secure.actblue.com/cf/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "kmdr",
-    "provider_url": "https://kmdr.sh",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://app.kmdr.sh/h/*",
-          "https://app.kmdr.sh/history/*"
-        ],
-        "url": "https://api.kmdr.sh/services/oembed"
-      }
-    ]
-  },
-  {
-    "provider_name": "uppy",
-    "provider_url": "https://uppy.jp",
-    "endpoints": [
-      {
-        "schemes": [
-          "https://app.uppy.jp/_shares/video/*"
-        ],
-        "url": "https://api.uppy.jp/v1/oembed",
+        "url": "https://srv2.zoomable.ca/oembed",
         "discovery": true
       }
     ]


### PR DESCRIPTION
This sync.js file does not account for schemes that are updated on existing providers. This is causing an issue with oembeds not properly being fetched when writing a new post within Ghost.

Since sync.js doesn't update schemes of existing providers, I replaced providers.json with an empty array and ran the sync.js command and was able to properly get updated info.

Old provider info:

```json
{
    "provider_name": "Audiomack",
    "provider_url": "https://www.audiomack.com",
    "endpoints": [
      {
        "schemes": [
          "https://www.audiomack.com/song/*",
          "https://www.audiomack.com/album/*",
          "https://www.audiomack.com/playlist/*"
        ],
        "url": "https://www.audiomack.com/oembed",
        "discovery": true
      }
    ]
  },
```

New provider info:

```json
{
    "provider_name": "Audiomack",
    "provider_url": "https://audiomack.com",
    "endpoints": [
      {
        "schemes": [
          "https://audiomack.com/*/song/*",
          "https://audiomack.com/*/album/*",
          "https://audiomack.com/*/playlist/*"
        ],
        "url": "https://audiomack.com/oembed",
        "discovery": true
      }
    ]
  },
```


