### PR TITLE
Add getLink method to API to allow users to run their own fetch

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,8 @@
 
 export function extract(url: string, params?: any): Promise<OembedData>;
 
+export function getLink(url: string, params?: any): string;
+
 export function hasProvider(url: string): boolean;
 
 export function setProviderList(providers: Provider[]): void
@@ -17,7 +19,7 @@ export interface Endpoint {
     formats?: string[]; // "json" "xml"
     discovery?: boolean;
 }
-  
+
 export interface Provider {
     "provider_name": string;
     "provider_url": string;

--- a/src/main.js
+++ b/src/main.js
@@ -31,8 +31,7 @@ const getLink = (url, params = {}) => {
   if (!p) {
     throw new Error(`No provider found with given url "${url}"`);
   }
-  const data = createLink(url, p, params);
-  return data;
+  return createLink(url, p, params);
 };
 
 const hasProvider = (url) => {

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ const {
   isValidURL,
   findProvider,
   fetchEmbed,
+  createLink,
   providersFromList,
 } = require('./utils');
 
@@ -22,6 +23,18 @@ const extract = async (url, params = {}) => {
   return data;
 };
 
+const getLink = (url, params = {}) => {
+  if (!isValidURL(url)) {
+    throw new Error('Invalid input URL');
+  }
+  const p = findProvider(url, providers);
+  if (!p) {
+    throw new Error(`No provider found with given url "${url}"`);
+  }
+  const data = createLink(url, p, params);
+  return data;
+};
+
 const hasProvider = (url) => {
   return findProvider(url, providers) !== null;
 };
@@ -32,6 +45,7 @@ const setProviderList = (list) => {
 
 module.exports = {
   extract,
+  getLink,
   hasProvider,
   setProviderList,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -19,8 +19,7 @@ const extract = async (url, params = {}) => {
   if (!p) {
     throw new Error(`No provider found with given url "${url}"`);
   }
-  const data = await fetchEmbed(url, p, params);
-  return data;
+  return fetchEmbed(url, p, params);
 };
 
 const getLink = (url, params = {}) => {

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -92,7 +92,7 @@ const hasInstagramKeys = (o) => {
 
 test(`test extract YouTube link`, async () => {
   try {
-    const url = 'https://www.youtube.com/watch?v=InVCZWzxpN4';
+    const url = 'https://www.youtube.com/watch?v=jNQXAC9IVRw';
     const result = await extract(url);
     expect(hasRichKeys(result)).toBe(true);
   } catch (err) {

--- a/src/utils/fetchEmbed.js
+++ b/src/utils/fetchEmbed.js
@@ -19,11 +19,6 @@ const getRegularUrl = (query, basseUrl) => {
 };
 
 const createLink = (url, provider, params = {}) => {
-  const {
-    provider_name, // eslint-disable-line camelcase
-    provider_url, // eslint-disable-line camelcase
-  } = provider;
-
   const queries = [
     'format=json',
     `url=${encodeURIComponent(url)}`,
@@ -47,7 +42,11 @@ const createLink = (url, provider, params = {}) => {
 };
 
 const fetchEmbed = async (url, provider, params = {}) => {
-  const link = createLink(url, provider, params = {});
+  const {
+    provider_name, // eslint-disable-line camelcase
+    provider_url, // eslint-disable-line camelcase
+  } = provider;
+  const link = createLink(url, provider, params);
   const res = await fetch(link, {mode: 'no-cors'});
   const json = await res.json();
   json.provider_name = provider_name; // eslint-disable-line camelcase

--- a/src/utils/fetchEmbed.js
+++ b/src/utils/fetchEmbed.js
@@ -37,8 +37,7 @@ const createLink = (url, provider, params = {}) => {
   }
   const query = queries.join('&');
 
-  const link = isInstagram(provider) ? getInstGraphUrl(query) : getRegularUrl(query, provider.url);
-  return link;
+  return isInstagram(provider) ? getInstGraphUrl(query) : getRegularUrl(query, provider.url);
 };
 
 const fetchEmbed = async (url, provider, params = {}) => {

--- a/src/utils/fetchEmbed.js
+++ b/src/utils/fetchEmbed.js
@@ -18,7 +18,7 @@ const getRegularUrl = (query, basseUrl) => {
   return basseUrl.replace(/\{format\}/g, 'json') + '?' + query;
 };
 
-const fetchEmbed = async (url, provider, params = {}) => {
+const createLink = (url, provider, params = {}) => {
   const {
     provider_name, // eslint-disable-line camelcase
     provider_url, // eslint-disable-line camelcase
@@ -43,6 +43,11 @@ const fetchEmbed = async (url, provider, params = {}) => {
   const query = queries.join('&');
 
   const link = isInstagram(provider) ? getInstGraphUrl(query) : getRegularUrl(query, provider.url);
+  return link;
+};
+
+const fetchEmbed = async (url, provider, params = {}) => {
+  const link = createLink(url, provider, params = {});
   const res = await fetch(link, {mode: 'no-cors'});
   const json = await res.json();
   json.provider_name = provider_name; // eslint-disable-line camelcase
@@ -50,4 +55,7 @@ const fetchEmbed = async (url, provider, params = {}) => {
   return json;
 };
 
-module.exports = fetchEmbed;
+module.exports = {
+  fetchEmbed,
+  createLink,
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   isValidURL: require('./isValidURL'),
   findProvider: require('./findProvider'),
-  fetchEmbed: require('./fetchEmbed'),
+  fetchEmbed: require('./fetchEmbed').fetchEmbed,
+  createLink: require('./fetchEmbed').createLink,
   providersFromList: require('./providersFromList'),
 };

--- a/sync.js
+++ b/sync.js
@@ -63,7 +63,7 @@ const merge = (data) => {
   writeFileSync(
     backup,
     JSON.stringify(providerList, undefined, 2),
-    'utf8'
+    'utf8',
   );
   data.filter(({provider_name}) => {
     return !blockedProviders.includes(provider_name);
@@ -84,7 +84,7 @@ const merge = (data) => {
   writeFileSync(
     target,
     JSON.stringify(providerList, undefined, 2),
-    'utf8'
+    'utf8',
   );
   console.log(`Providers list has been updated`);
 };


### PR DESCRIPTION
I needed to run this code on a node server in a container where all external requests must pass through a proxy. I separated out the link creation from the fetchEmbed so I could export and add a getLink method to the API.

For reference I needed to do something like this with the library.

```js
const oembed = require('oembed-parser');

const getOEmbed = async (url) => {
  const link = oembed.getLink(url);

  const response = await axios.get(link, {
    proxy: {
      host: 'proxy.yourdomain.com',
      port: 8888,
    },
  });
  
  return response;
};
```

I'd love to hear your thoughts, and if you could use this in your library would you like me to change anything, add tests, etc?
Thanks!