### PR TITLE
Allow params besides maxheight & maxwidth

### DIFF
--- a/src/main.test.js
+++ b/src/main.test.js
@@ -217,7 +217,9 @@ describe('test if extract() with some popular providers', () => {
         maxheight = 0
       } = params
 
-      const result = await extract(url, provider, { maxwidth, maxheight })
+      //  `extract()` takes 2 args: url & params but not provider
+      //  const result = await extract(url, provider, { maxwidth, maxheight })
+      const result = await extract(url, { maxwidth, maxheight })
       expect(result).toBeTruthy()
       expect(checkFn(result)).toBe(true)
       expect(result.provider_name).toEqual(expected.provider_name)

--- a/src/utils/fetchEmbed.js
+++ b/src/utils/fetchEmbed.js
@@ -24,23 +24,25 @@ const fetchEmbed = async (url, provider, params = {}) => {
     `url=${encodeURIComponent(url)}`
   ]
 
-  const {
-    maxwidth = 0,
-    maxheight = 0
-  } = params
-
-  if (maxwidth > 0) {
-    queries.push(`maxwidth=${maxwidth}`)
+  // remove these if they're set to zero
+  if (params.maxwidth <= 0) {
+    delete params.maxwidth
   }
-  if (maxheight > 0) {
-    queries.push(`maxheight=${maxheight}`)
+  if (params.maxheight <= 0) {
+    delete params.maxheight
   }
 
   if (isFacebookGraphDependent(provider.providerUrl)) {
     queries.push(getFacebookGraphToken())
   }
 
-  const query = queries.join('&')
+  const queryParams = new URLSearchParams(params).toString()
+
+  let query = queries.join('&')
+
+  if (queryParams) {
+    query = query + '&' + queryParams
+  }
 
   const link = getRegularUrl(query, provider.fetchEndpoint)
   const body = retrieve(link)

--- a/src/utils/fetchEmbed.test.js
+++ b/src/utils/fetchEmbed.test.js
@@ -38,6 +38,16 @@ describe('test if fetchEmbed() works correctly', () => {
     },
     {
       input: {
+        url: 'https://twitter.com/ndaidong/status/1173592062878314497?theme=dark',
+        file: './test-data/twitter-dark.json'
+      },
+      expected: {
+        provider_name: 'Twitter',
+        type: 'rich'
+      }
+    },
+    {
+      input: {
         url: 'https://www.facebook.com/facebook/videos/10153231379946729/',
         params: {
           access_token: '845078789498971|8ff3ab4ddd45b8f018b35c4fb7edac62'

--- a/test-data/twitter-dark.json
+++ b/test-data/twitter-dark.json
@@ -1,0 +1,13 @@
+{
+  "url": "https://twitter.com/ndaidong/status/1173592062878314497",
+  "author_name": "Dong Nguyen",
+  "author_url": "https://twitter.com/ndaidong",
+  "html": "<blockquote class=\"twitter-tweet\" data-theme=\"dark\"><p lang=\"en\" dir=\"ltr\">Live event: Release Lotus - New social network in Vietnam<a href=\"https://t.co/BWGejBZRWh\">https://t.co/BWGejBZRWh</a><a href=\"https://twitter.com/hashtag/lotus?src=hash&amp;ref_src=twsrc%5Etfw\">#lotus</a> <a href=\"https://twitter.com/hashtag/SocialNetwork?src=hash&amp;ref_src=twsrc%5Etfw\">#SocialNetwork</a></p>&mdash; Dong Nguyen (@ndaidong) <a href=\"https://twitter.com/ndaidong/status/1173592062878314497?ref_src=twsrc%5Etfw\">September 16, 2019</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n",
+  "width": 550,
+  "height": null,
+  "type": "rich",
+  "cache_age": "3153600000",
+  "provider_name": "Twitter",
+  "provider_url": "https://twitter.com",
+  "version": "1.0"
+}


### PR DESCRIPTION
Some providers allow additional query params
beyond what's require in the oEmbed spec.
For example: dartk theme tweets

https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/oembed-api