### PR TITLE
Correcting spelling error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # oembed-parser
 
-Extract eEmbed content from given URL.
+Extract oEmbed content from given URL.
 
 [![NPM](https://badge.fury.io/js/oembed-parser.svg)](https://badge.fury.io/js/oembed-parser)
 [![CI test](https://github.com/ndaidong/oembed-parser/workflows/ci-test/badge.svg)](https://github.com/ndaidong/oembed-parser/actions)


### PR DESCRIPTION
This was a minor error I spotted in the README while reviewing the documentation, but I figured it was worth correcting. 