### PR TITLE
Fix spotify oembed url

### DIFF
--- a/src/utils/providers.latest.js
+++ b/src/utils/providers.latest.js
@@ -3105,7 +3105,7 @@ export const providers = [
           "https://open.spotify.com/*",
           "spotify:*"
         ],
-        "url": "https://open.spotify.com/oembed/",
+        "url": "https://open.spotify.com/oembed",
         "discovery": true
       }
     ]


### PR DESCRIPTION
Hey there, it looks like Spotify's oembed url contains an ending slash which causes a redirect (which normally isn't an issue), but this throws a CORS error because they don't include any of the CORS headers. This PR simply removes the slash.