### PR TITLE
added findProvider to type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,8 @@ export function extract(url: string, params?: any): Promise<OembedData>;
 
 export function hasProvider(url: string): boolean
 
+export function findProvider(url: string): FoundProvider
+
 export function setProviderList(providers: Provider[]): void
 
 export function setRequestOptions(options: object): void
@@ -26,6 +28,12 @@ export interface Provider {
     "provider_name": string;
     "provider_url": string;
     "endpoints": Endpoint[];
+}
+
+export interface FindProviderResult {
+    "fetchEndpoint": string;
+    "provider_name": string;
+    "provider_url": string;
 }
 /**
  * Basic data structure of every oembed response see https://oembed.com/


### PR DESCRIPTION
Hey, I was trying to use `findProvider()` in a project of mine – unfortunately that function hadn't been added to the type manifest, so I wasn't able to import it into any .tsx files in my project. This pull request should rectify the issue.