### PR TITLE
Remove default tokens to prevent credential leaks

### DIFF
--- a/src/utils/fetchEmbed.js
+++ b/src/utils/fetchEmbed.js
@@ -8,8 +8,8 @@ const isFacebookGraphDependent = (url) => {
 
 const getFacebookGraphToken = () => {
   const env = process.env || {}
-  const appId = env.FACEBOOK_APP_ID || '845078789498971'
-  const clientToken = env.FACEBOOK_CLIENT_TOKEN || '8ff3ab4ddd45b8f018b35c4fb7edac62'
+  const appId = env.FACEBOOK_APP_ID
+  const clientToken = env.FACEBOOK_CLIENT_TOKEN
 
   return `${appId}|${clientToken}`
 }


### PR DESCRIPTION
Does not touch unit tests, which would not be included in a compiled package and thus are not susceptible to credential leak in the same way.

However, it might be worth updating those to pull from `process.env` as well, and removing all credentials from the repo.